### PR TITLE
Fix: Ensure correct leader display in team card

### DIFF
--- a/blockwarriors-next/src/app/dashboard/setup/team/team-card.tsx
+++ b/blockwarriors-next/src/app/dashboard/setup/team/team-card.tsx
@@ -123,14 +123,11 @@ export function TeamCard({
                   {member.first_name} {member.last_name}
                 </span>
               </div>
-              {member.first_name ===
-                members.find((m) => m.first_name)?.first_name &&
-                member.last_name ===
-                  members.find((m) => m.last_name)?.last_name && (
-                  <Badge variant="outline" className="text-xs">
-                    Leader
-                  </Badge>
-                )}
+              {member.user_id === leader_id && (
+                <Badge variant="outline" className="text-xs">
+                  Leader
+                </Badge>
+              )}
             </div>
           ))}
         </div>

--- a/blockwarriors-next/src/types/team.ts
+++ b/blockwarriors-next/src/types/team.ts
@@ -10,6 +10,7 @@ export interface Team {
 export interface TeamMember {
   first_name: string;
   last_name: string;
+  user_id: string;
 }
 
 export interface TeamWithUsers extends Team {


### PR DESCRIPTION
**Description:**

This PR addresses an issue where multiple leaders could be displayed in the team card if members had the same first and last names.

- Updated the TeamMember type in src/types/team.ts to include user_id.
- Modified the leader display logic in src/app/dashboard/setup/team/team-card.tsx to use the leader_id prop and the member.user_id for an accurate comparison. The Supabase function get_all_teams_with_members was already correctly populating the user_id.