### PR TITLE
feat: updated package.json & Convex HTTP action

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10248,9 +10248,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12816,9 +12816,9 @@
       }
     },
     "node_modules/sucrase/node_modules/glob": {
-      "version": "10.4.5",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
-      "integrity": "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
       "license": "ISC",
       "dependencies": {
         "foreground-child": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "description": "BlockWarriors Command Block monorepo",
-  "packageManager": "npm@10.9.3",
+  "packageManager": "npm@11.6.3",
   "engines": {
     "node": ">=20.9.0"
   },

--- a/packages/backend/convex/http.ts
+++ b/packages/backend/convex/http.ts
@@ -1,9 +1,21 @@
 import { httpRouter } from "convex/server";
 import { authComponent, createAuth } from "./auth";
+import { httpAction } from "./_generated/server";
 
 const http = httpRouter();
 
 authComponent.registerRoutes(http, createAuth);
+
+http.route({
+  path: "/hello",
+  method: "GET",
+  handler: httpAction(async () => {
+    return new Response("Hello, world!", {
+      status: 200,
+      headers: { "Content-Type": "text/plain" }
+    });
+  }),
+});
 
 export default http;
 


### PR DESCRIPTION
- Uplifted NPM version from `npm@10.9.3` to `npm@11.6.3`
- Added a `/hello` Convex HTTP action for testing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Convex `GET /hello` HTTP action and updates the project to use `npm@11.6.3` (with lockfile bumps).
> 
> - **Backend**:
>   - **HTTP route**: Add `GET /hello` in `packages/backend/convex/http.ts` using `httpAction`, returning plain-text "Hello, world!".
> - **Tooling/Config**:
>   - Bump `packageManager` in `package.json` to `npm@11.6.3`.
>   - Lockfile updates: `js-yaml` → `4.1.1`, `glob` (via `sucrase`) → `10.5.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3be1471c609ba5d5911964ed006c643128017642. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->