### PR TITLE
Enhance Convex integration by adding HTTP secret management and confi…

### DIFF
--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchManager.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchManager.java
@@ -16,6 +16,7 @@ public class MatchManager {
     private static final Logger LOGGER = Logger.getLogger("beacon");
     private final JavaPlugin plugin;
     private final String convexSiteUrl;
+    private final String convexHttpSecret;
     private MatchTelemetryService telemetryService;
     
     // Map match ID to world name
@@ -27,9 +28,10 @@ public class MatchManager {
     // Map player UUID to match ID
     private final Map<UUID, String> playerMatches = new HashMap<>();
 
-    public MatchManager(JavaPlugin plugin, String convexSiteUrl) {
+    public MatchManager(JavaPlugin plugin, String convexSiteUrl, String convexHttpSecret) {
         this.plugin = plugin;
         this.convexSiteUrl = convexSiteUrl;
+        this.convexHttpSecret = convexHttpSecret;
     }
 
     public void setTelemetryService(MatchTelemetryService telemetryService) {
@@ -101,9 +103,6 @@ public class MatchManager {
         new BukkitRunnable() {
             @Override
             public void run() {
-                // Kick all players from the match world
-                World world = Bukkit.getWorld(worldName);
-                // Intentionally do not check for world == null; let it throw if something is wrong
                 for (UUID playerId : playerIds) {
                     Player player = Bukkit.getPlayer(playerId);
                     if (player != null && player.isOnline()) {
@@ -146,6 +145,7 @@ public class MatchManager {
             java.net.HttpURLConnection conn = (java.net.HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Authorization", "Bearer " + convexHttpSecret);
             conn.setDoOutput(true);
 
             org.json.JSONObject requestBody = new org.json.JSONObject();

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchPollingService.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchPollingService.java
@@ -26,13 +26,15 @@ public class MatchPollingService {
     private static final Logger LOGGER = Logger.getLogger("beacon");
     private final JavaPlugin plugin;
     private final String convexSiteUrl;
+    private final String convexHttpSecret;
     private MatchManager matchManager;
     private int taskId = -1;
     private static final int POLL_INTERVAL_SECONDS = 5; // Poll every 5 seconds
 
-    public MatchPollingService(JavaPlugin plugin, String convexSiteUrl) {
+    public MatchPollingService(JavaPlugin plugin, String convexSiteUrl, String convexHttpSecret) {
         this.plugin = plugin;
         this.convexSiteUrl = convexSiteUrl;
+        this.convexHttpSecret = convexHttpSecret;
     }
 
     public void setMatchManager(MatchManager matchManager) {
@@ -289,6 +291,7 @@ public class MatchPollingService {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Authorization", "Bearer " + convexHttpSecret);
             conn.setDoOutput(true);
 
             // Only send match_id - Convex will determine tokens_per_team from match_type
@@ -347,6 +350,7 @@ public class MatchPollingService {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Authorization", "Bearer " + convexHttpSecret);
 
             int responseCode = conn.getResponseCode();
             if (responseCode != 200) {
@@ -403,6 +407,7 @@ public class MatchPollingService {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Authorization", "Bearer " + convexHttpSecret);
             conn.setDoOutput(true);
 
             JSONObject requestBody = new JSONObject();
@@ -446,6 +451,7 @@ public class MatchPollingService {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Authorization", "Bearer " + convexHttpSecret);
 
             int responseCode = conn.getResponseCode();
             if (responseCode != 200) {
@@ -566,6 +572,7 @@ public class MatchPollingService {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Authorization", "Bearer " + convexHttpSecret);
 
             int responseCode = conn.getResponseCode();
             if (responseCode != 200) {
@@ -641,6 +648,7 @@ public class MatchPollingService {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("GET");
             conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Authorization", "Bearer " + convexHttpSecret);
 
             int responseCode = conn.getResponseCode();
             if (responseCode != 200) {

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchTelemetryService.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchTelemetryService.java
@@ -29,14 +29,16 @@ public class MatchTelemetryService {
     private static final Logger LOGGER = Logger.getLogger("beacon");
     private final JavaPlugin plugin;
     private final String convexSiteUrl;
+    private final String convexHttpSecret;
     private final Map<String, Set<UUID>> activeMatches = new HashMap<>(); // matchId -> Set of player UUIDs
     private final Map<UUID, String> playerToMatch = new HashMap<>(); // player UUID -> matchId
     private int taskId = -1;
     private static final long UPDATE_INTERVAL_TICKS = 20L; // Update every second (20 ticks)
 
-    public MatchTelemetryService(JavaPlugin plugin, String convexSiteUrl) {
+    public MatchTelemetryService(JavaPlugin plugin, String convexSiteUrl, String convexHttpSecret) {
         this.plugin = plugin;
         this.convexSiteUrl = convexSiteUrl;
+        this.convexHttpSecret = convexHttpSecret;
     }
 
     public void start() {
@@ -362,6 +364,7 @@ public class MatchTelemetryService {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestMethod("POST");
             conn.setRequestProperty("Content-Type", "application/json");
+            conn.setRequestProperty("Authorization", "Bearer " + convexHttpSecret);
             conn.setDoOutput(true);
 
             JSONObject requestBody = new JSONObject();

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/LoginCommand.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/LoginCommand.java
@@ -17,17 +17,18 @@ import java.util.UUID;
 import java.util.logging.Logger;
 
 import org.json.JSONObject;
-import org.json.JSONException;
 
 public class LoginCommand implements CommandExecutor {
 
     private final Set<UUID> loggedInPlayers;
     private final String convexSiteUrl;
+    private final String convexHttpSecret;
     private static final Logger LOGGER = Logger.getLogger("beacon");
 
-    public LoginCommand(Set<UUID> loggedInPlayersInput, String convexSiteUrl) {
+    public LoginCommand(Set<UUID> loggedInPlayersInput, String convexSiteUrl, String convexHttpSecret) {
         loggedInPlayers = loggedInPlayersInput;
         this.convexSiteUrl = convexSiteUrl;
+        this.convexHttpSecret = convexHttpSecret;
     }
 
     @Override
@@ -42,7 +43,6 @@ public class LoginCommand implements CommandExecutor {
             return true;
         }
 
-        Logger logger = Bukkit.getLogger();
         Player player = (Player) sender;
 
         if (args.length != 1) {
@@ -64,6 +64,7 @@ public class LoginCommand implements CommandExecutor {
                     HttpURLConnection conn = (HttpURLConnection) url.openConnection();
                     conn.setRequestMethod("POST");
                     conn.setRequestProperty("Content-Type", "application/json");
+                    conn.setRequestProperty("Authorization", "Bearer " + convexHttpSecret);
                     conn.setDoOutput(true);
 
                     JSONObject requestBody = new JSONObject();

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/events/WorldEventListener.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/events/WorldEventListener.java
@@ -6,8 +6,6 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntitySpawnEvent;
 
-import java.util.logging.Logger;
-
 /**
  * Prevents mob spawning in match worlds
  */

--- a/apps/blockwarriors-beacon/src/main/resources/config.yml
+++ b/apps/blockwarriors-beacon/src/main/resources/config.yml
@@ -1,0 +1,11 @@
+# Convex Backend Configuration
+# These settings configure the connection between the beacon plugin and Convex backend
+
+# The Convex site URL for HTTP API calls
+convex-site-url: "https://abundant-ferret-667.convex.site"
+
+# The shared secret for server-to-server authentication
+# Generate with: openssl rand -base64 32
+# Must match the CONVEX_HTTP_SECRET environment variable set in Convex
+convex-http-secret: "your-secret-here"
+

--- a/apps/blockwarriors-next/src/app/dashboard/matches/[id]/page.tsx
+++ b/apps/blockwarriors-next/src/app/dashboard/matches/[id]/page.tsx
@@ -99,8 +99,14 @@ export default function MatchDetailPage() {
             <ClockIcon className="w-5 h-5" />
             <span className="text-sm font-medium">Mode</span>
           </div>
-          <p className="text-2xl font-semibold text-white capitalize">
-            {matchData.mode}
+          <p
+            className={`text-2xl font-semibold capitalize ${
+              matchData.mode === 'ranked'
+                ? 'text-amber-400'
+                : 'text-cyan-400'
+            }`}
+          >
+            {matchData.mode === 'ranked' ? 'Ranked' : 'Practice'}
           </p>
         </div>
 

--- a/apps/blockwarriors-next/src/app/dashboard/practice/page.tsx
+++ b/apps/blockwarriors-next/src/app/dashboard/practice/page.tsx
@@ -12,7 +12,7 @@ import {
   CommandLineIcon,
 } from '@heroicons/react/24/outline';
 import { authClient } from '@/lib/auth-client';
-import { GAME_MODES, type GameMode } from '@/lib/match-constants';
+import { GAME_TYPES, type GameType } from '@/lib/match-constants';
 import { startMatch } from '@/server/actions/matches';
 import { api } from '@/lib/convex';
 import { Id } from '@packages/backend/convex/_generated/dataModel';
@@ -25,7 +25,7 @@ interface ServerStatus {
 
 export default function PracticePage() {
   const router = useRouter();
-  const [selectedMode, setSelectedMode] = useState<GameMode | null>(null);
+  const [selectedGameType, setSelectedGameType] = useState<GameType | null>(null);
   const [serverStatus, setServerStatus] = useState<ServerStatus>({
     activeSessions: 0,
     playersOnline: 0,
@@ -67,14 +67,14 @@ export default function PracticePage() {
 
   // Check if button should be disabled
   const isButtonDisabled = Boolean(
-    !selectedMode ||
+    !selectedGameType ||
       isLoading ||
       waitingForTokens ||
       matchId // Disable button after match is created (waiting for players or auto-starting)
   );
 
   // Use centralized game mode configuration
-  const gameModes = Object.values(GAME_MODES).map((mode) => ({
+  const gameModes = Object.values(GAME_TYPES).map((mode) => ({
     id: mode.id,
     name: mode.name,
     description: mode.description,
@@ -85,12 +85,12 @@ export default function PracticePage() {
   const serverAddress = 'play.blockwarriors.ai';
 
   const handleStartMatch = async () => {
-    if (!selectedMode) return;
+    if (!selectedGameType) return;
 
     setIsLoading(true);
 
     try {
-      const result = await startMatch(selectedMode);
+      const result = await startMatch(selectedGameType);
 
       if (result.error) {
         console.error('Failed to start match:', result.error);
@@ -131,11 +131,11 @@ export default function PracticePage() {
           <motion.div
             key={mode.id}
             className={`bg-black/40 backdrop-blur-md rounded-lg p-6 cursor-pointer border-2 transition-all ${
-              selectedMode === mode.id
+              selectedGameType === mode.id
                 ? 'border-blue-500 bg-black/60'
                 : 'border-transparent hover:border-white/20'
             }`}
-            onClick={() => setSelectedMode(mode.id as GameMode)}
+            onClick={() => setSelectedGameType(mode.id as GameType)}
             whileHover={{ scale: 1.02 }}
             whileTap={{ scale: 0.98 }}
           >
@@ -145,7 +145,7 @@ export default function PracticePage() {
             <p className="text-gray-400 text-sm mb-4">{mode.description}</p>
             <div className="flex items-center justify-between text-sm">
               <span className="text-gray-500">{mode.players}</span>
-              {selectedMode === mode.id && (
+              {selectedGameType === mode.id && (
                 <span className="text-blue-400">Selected</span>
               )}
             </div>
@@ -274,12 +274,11 @@ export default function PracticePage() {
           <div className="flex items-center gap-2">
             <div className="animate-spin rounded-full h-5 w-5 border-b-2 border-yellow-400"></div>
             <h3 className="text-yellow-400 font-medium">
-              Waiting for Server Acknowledgment
+              Waiting for Minecraft server
             </h3>
           </div>
           <p className="text-sm text-gray-400">
-            Match created! Waiting for Minecraft server to acknowledge and
-            generate tokens...
+            Waiting for Minecraft server to prepare the match...
           </p>
           {matchId && (
             <div className="text-xs text-gray-500 font-mono">

--- a/apps/blockwarriors-next/src/lib/match-constants.ts
+++ b/apps/blockwarriors-next/src/lib/match-constants.ts
@@ -2,10 +2,14 @@
  * Match configuration constants and type definitions
  */
 
-export type GameMode = 'pvp' | 'bedwars' | 'ctf';
+// Game types (pvp, bedwars, ctf) - determines the game being played
+export type GameType = 'pvp' | 'bedwars' | 'ctf';
 
-export interface GameModeConfig {
-  id: GameMode;
+// Match modes - determines competitive context (practice vs ranked)
+export type MatchMode = 'practice' | 'ranked';
+
+export interface GameTypeConfig {
+  id: GameType;
   name: string;
   description: string;
   players: string;
@@ -13,7 +17,7 @@ export interface GameModeConfig {
   tokensPerTeam: number;
 }
 
-export const GAME_MODES: Record<GameMode, GameModeConfig> = {
+export const GAME_TYPES: Record<GameType, GameTypeConfig> = {
   pvp: {
     id: 'pvp',
     name: 'Normal PvP',
@@ -40,22 +44,40 @@ export const GAME_MODES: Record<GameMode, GameModeConfig> = {
   },
 };
 
+export const MATCH_MODES: Record<MatchMode, { id: MatchMode; name: string; description: string }> = {
+  practice: {
+    id: 'practice',
+    name: 'Practice',
+    description: 'Casual matches for testing and learning',
+  },
+  ranked: {
+    id: 'ranked',
+    name: 'Ranked',
+    description: 'Competitive matches that affect team ELO',
+  },
+};
+
 /**
- * Get game mode configuration
+ * Get game type configuration
  */
-export function getGameModeConfig(mode: GameMode): GameModeConfig {
-  const config = GAME_MODES[mode];
+export function getGameTypeConfig(gameType: GameType): GameTypeConfig {
+  const config = GAME_TYPES[gameType];
   if (!config) {
-    throw new Error(`Invalid game mode: ${mode}`);
+    throw new Error(`Invalid game type: ${gameType}`);
   }
   return config;
 }
 
 /**
- * Validate if a string is a valid game mode
+ * Validate if a string is a valid game type
  */
-export function isValidGameMode(mode: string): mode is GameMode {
-  return mode in GAME_MODES;
+export function isValidGameType(gameType: string): gameType is GameType {
+  return gameType in GAME_TYPES;
 }
 
-
+/**
+ * Validate if a string is a valid match mode
+ */
+export function isValidMatchMode(mode: string): mode is MatchMode {
+  return mode in MATCH_MODES;
+}

--- a/apps/warrior-telemetry/src/main/java/ai/blockwarriors/warriorTelemetry/events/WarriorEventListener.java
+++ b/apps/warrior-telemetry/src/main/java/ai/blockwarriors/warriorTelemetry/events/WarriorEventListener.java
@@ -1,6 +1,9 @@
 package ai.blockwarriors.warriorTelemetry.events;
 
 import ai.blockwarriors.warriorTelemetry.Plugin;
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.md_5.bungee.api.ChatColor;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -59,8 +62,8 @@ public class WarriorEventListener implements Listener {
         ScoreboardManager manager = Bukkit.getScoreboardManager();
         Scoreboard scoreboard = manager.getNewScoreboard();
 
-        Objective objective = scoreboard.registerNewObjective("warrior", "dummy",
-            ChatColor.GOLD + "" + ChatColor.BOLD + target.getName());
+        Objective objective = scoreboard.registerNewObjective("warrior", Criteria.DUMMY,
+            Component.text(target.getName()).color(NamedTextColor.GOLD).decorate(TextDecoration.BOLD));
         objective.setDisplaySlot(DisplaySlot.SIDEBAR);
 
         Location loc = target.getLocation();

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -86,9 +86,12 @@ npx convex dev
    npx convex env set GOOGLE_CLIENT_ID your_google_client_id
    npx convex env set GOOGLE_CLIENT_SECRET your_google_client_secret
    npx convex env set BETTER_AUTH_SECRET $(openssl rand -base64 32)
+   npx convex env set CONVEX_HTTP_SECRET $(openssl rand -base64 32)
    npx convex env set SITE_URL http://localhost:3000
    # For production, set SITE_URL to your public site URL
    ```
+
+   Note: `CONVEX_HTTP_SECRET` is used for server-to-server authentication between the Minecraft beacon plugin and Convex. Copy this same secret to `plugins/beacon/config.yml` on your Minecraft server.
 
    These are required because Convex auth (in `packages/backend/convex/auth.ts`) reads from `process.env` inside the Convex runtime.
 


### PR DESCRIPTION
## Summary

This PR enhances the Convex integration by adding HTTP secret management for secure server-to-server authentication

## Changes

### Security & Authentication
- Add `CONVEX_HTTP_SECRET` configuration for server-to-server authentication
- Update `MatchManager`, `MatchPollingService`, and `MatchTelemetryService` to utilize the new secret
- Refactor `LoginCommand` to include the secret in requests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce server-to-server bearer authentication with CONVEX_HTTP_SECRET across Convex HTTP routes and beacon plugin, add config, and refactor frontend from game modes to game types with practice flow updates.
> 
> - **Security / Backend**:
>   - Add bearer auth for Convex HTTP routes using `CONVEX_HTTP_SECRET` (`verifyBearerToken` + 401 responses) in `packages/backend/convex/http.ts`.
>   - Beacon plugin now reads `convex-site-url` and `convex-http-secret` from `config.yml`/env and sends `Authorization: Bearer <secret>` on all HTTP calls (`LoginCommand`, `MatchManager`, `MatchPollingService`, `MatchTelemetryService`).
>   - Add `apps/blockwarriors-beacon/src/main/resources/config.yml` with Convex settings.
> - **Minecraft Plugin**:
>   - Update constructors/signatures to accept `convexHttpSecret` and pass through to services; all match status/state/tokens endpoints now authenticated.
>   - Tighten world spawn control in `WorldEventListener` to block non-player spawns in `match_*` worlds.
> - **Frontend (Next.js)**:
>   - Rename `GAME_MODES` → `GAME_TYPES`; introduce `GameType`, `MatchMode`, and validators in `lib/match-constants.ts`.
>   - Update Practice page to use `gameType`, disable flow until selection, and improved waiting copy; `startMatch` now posts `{ match_type: gameType, mode: 'practice' }`.
>   - Match detail page shows colored `mode` badge (Ranked/Practice).
> - **Docs**:
>   - Onboarding adds `CONVEX_HTTP_SECRET` setup and notes for syncing with beacon.
> - **Warrior Telemetry**:
>   - Switch scoreboard objective creation to Adventure API (`Criteria.DUMMY` + `Component` title).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 131b7421f8d796165c5203fa1bf7ee886b2a1e28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->