### PR TITLE
Add Mineflayer Testing Client

### DIFF
--- a/apps/blockwarriors-next/src/app/dashboard/practice/page.tsx
+++ b/apps/blockwarriors-next/src/app/dashboard/practice/page.tsx
@@ -25,7 +25,9 @@ interface ServerStatus {
 
 export default function PracticePage() {
   const router = useRouter();
-  const [selectedGameType, setSelectedGameType] = useState<GameType | null>(null);
+  const [selectedGameType, setSelectedGameType] = useState<GameType | null>(
+    null
+  );
   const [serverStatus, setServerStatus] = useState<ServerStatus>({
     activeSessions: 0,
     playersOnline: 0,
@@ -67,10 +69,7 @@ export default function PracticePage() {
 
   // Check if button should be disabled
   const isButtonDisabled = Boolean(
-    !selectedGameType ||
-      isLoading ||
-      waitingForTokens ||
-      matchId // Disable button after match is created (waiting for players or auto-starting)
+    !selectedGameType || isLoading || waitingForTokens || matchId // Disable button after match is created (waiting for players or auto-starting)
   );
 
   // Use centralized game mode configuration
@@ -82,7 +81,7 @@ export default function PracticePage() {
     tokens: mode.tokensPerMatch,
   }));
 
-  const serverAddress = 'play.blockwarriors.ai';
+  const serverAddress = 'mcpanel.blockwarriors.ai:25565';
 
   const handleStartMatch = async () => {
     if (!selectedGameType) return;
@@ -112,7 +111,6 @@ export default function PracticePage() {
       setIsLoading(false);
     }
   };
-
 
   return (
     <motion.div

--- a/apps/mineflayer-tester/.gitignore
+++ b/apps/mineflayer-tester/.gitignore
@@ -1,0 +1,22 @@
+# Dependencies
+node_modules/
+
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Environment
+.env
+.env.local
+.env.*.local
+
+# OS
+.DS_Store
+Thumbs.db

--- a/apps/mineflayer-tester/README.md
+++ b/apps/mineflayer-tester/README.md
@@ -1,0 +1,220 @@
+# BlockWarriors Mineflayer Testing Client
+
+A standalone web-based testing client for controlling Mineflayer bots to test the BlockWarriors Minecraft server.
+
+## Features
+
+- **Multi-Bot Management**: Create and manage multiple bot instances simultaneously
+- **Token Authentication**: Login bots using BlockWarriors authentication tokens
+- **Real-time GUI**: Web interface with live updates via WebSocket
+- **Bot Control Commands**:
+  - Chat messages
+  - Attack/kill players
+  - Follow players
+  - Move to coordinates
+  - Disconnect/reconnect
+- **Observability**: Real-time logs, position tracking, health monitoring, and player list
+
+## Prerequisites
+
+- Node.js >= 20.9.0
+- Access to BlockWarriors matches with authentication tokens
+
+## Installation
+
+1. Navigate to the app directory:
+```bash
+cd apps/mineflayer-tester
+```
+
+2. Install dependencies:
+```bash
+npm install
+```
+
+## Usage
+
+### Starting the Client
+
+Run the development server:
+```bash
+npm run dev
+```
+
+The web interface will be available at: [http://localhost:3000](http://localhost:3000)
+
+### Creating and Connecting Bots
+
+1. **Get Authentication Tokens**:
+   - Go to the BlockWarriors dashboard
+   - Create a match (Practice or Ranked)
+   - Wait for match status to change to "Waiting"
+   - Copy the authentication tokens from the match page
+
+2. **Create a Bot**:
+   - Click "Add Bot" in the web interface
+   - Enter a username for the bot
+   - Click "Create"
+
+3. **Connect the Bot**:
+   - Click "Connect" on the bot card
+   - Paste the authentication token
+   - The bot will connect to `play.blockwarriors.ai` and automatically run `/login <token>`
+
+4. **Control the Bot**:
+   - **Chat**: Send messages in the Minecraft chat
+   - **Attack**: Target a player by username to attack them
+   - **Follow**: Follow a player by username
+   - **Move**: Move to specific X, Y, Z coordinates
+
+### Bot Testing Workflow
+
+Here's a typical testing workflow:
+
+1. **Create a Match**:
+   - Go to BlockWarriors dashboard
+   - Create a PvP practice match
+   - Wait for tokens to be generated (status: "Waiting")
+
+2. **Connect Bots**:
+   - Create 2 bots in the testing client (e.g., "TestBot1", "TestBot2")
+   - Connect each bot with a different token from the match
+
+3. **Test Combat**:
+   - Use the "Attack" command to make one bot attack the other
+   - Watch the logs for combat events
+   - Monitor health and position in real-time
+
+4. **Test Movement**:
+   - Use "Follow" to make a bot follow another player
+   - Use "Move" to send bots to specific coordinates
+   - Observe pathfinding behavior
+
+5. **Test Communication**:
+   - Send chat messages from bots
+   - Verify messages appear in-game
+
+## Architecture
+
+```
+apps/mineflayer-tester/
+├── src/
+│   ├── index.js           # Entry point
+│   ├── server.js          # Express + Socket.io server
+│   ├── bot-manager.js     # Manages multiple bot instances
+│   ├── bot-instance.js    # Individual Mineflayer bot wrapper
+│   └── public/
+│       ├── index.html     # Web GUI
+│       ├── styles.css     # Styling
+│       └── app.js         # Frontend JavaScript
+└── package.json
+```
+
+### Technology Stack
+
+- **Backend**: Node.js, Express, Socket.io
+- **Bot Client**: Mineflayer (Minecraft bot framework)
+- **Frontend**: Vanilla HTML/CSS/JavaScript
+- **Real-time Communication**: WebSocket (Socket.io)
+
+## How It Works
+
+### Authentication Flow
+
+1. Bot connects to `play.blockwarriors.ai` in offline mode
+2. Once logged in, bot automatically sends `/login <token>` command
+3. BlockWarriors Minecraft plugin validates token via Convex backend
+4. If valid, bot is added to the match and can participate
+
+### Bot Control
+
+- Each bot runs as a Mineflayer instance in Node.js
+- BotManager coordinates multiple bot instances
+- WebSocket provides real-time communication between server and GUI
+- Bot events (chat, health, position, etc.) are forwarded to the web interface
+
+### Real-time Updates
+
+- **Logs**: All bot activity (chat, errors, status changes)
+- **Status**: Connection state, health, food level
+- **Position**: X, Y, Z coordinates (throttled to 500ms)
+- **Player List**: Other players visible to the bot
+
+## API Reference
+
+### REST Endpoints
+
+- `GET /api/bots` - Get all bot states
+- `POST /api/bots/create` - Create a new bot
+- `POST /api/bots/:id/connect` - Connect bot with token
+- `POST /api/bots/:id/disconnect` - Disconnect bot
+- `DELETE /api/bots/:id` - Remove bot
+- `POST /api/bots/:id/chat` - Send chat message
+- `POST /api/bots/:id/kill` - Attack a player
+- `POST /api/bots/:id/stop-attack` - Stop attacking
+- `POST /api/bots/:id/follow` - Follow a player
+- `POST /api/bots/:id/move` - Move to coordinates
+
+### WebSocket Events
+
+**Client → Server**: (Handled via REST API)
+
+**Server → Client**:
+- `bots-update` - Full bot state update
+- `log` - Log message from a bot
+- `error` - Error from a bot
+- `status` - Status update (health, connection, etc.)
+- `position` - Position update
+
+## Troubleshooting
+
+### Bot Won't Connect
+
+- Verify the token is valid and not expired (15-minute expiration)
+- Check that the match is in "Waiting" status
+- Ensure `play.blockwarriors.ai` is accessible
+
+### Authentication Failed
+
+- Make sure you're using a fresh token from an active match
+- Tokens can only be used once
+- Check the logs for specific error messages from the server
+
+### Bot Disconnects
+
+- Minecraft server may kick idle bots
+- Check server logs for kick reasons
+- Verify network connectivity
+
+## Development
+
+### Adding New Commands
+
+1. Add method to `BotInstance` class in [bot-instance.js](src/bot-instance.js)
+2. Add API endpoint in [server.js](src/server.js)
+3. Add UI button and handler in [app.js](src/public/app.js)
+
+### Customization
+
+- **Port**: Set `PORT` environment variable (default: 3000)
+- **Server**: Modify host in [bot-instance.js:35](src/bot-instance.js#L35)
+- **Styling**: Edit [styles.css](src/public/styles.css)
+
+## Limitations
+
+- Bots use offline mode authentication (token-based via `/login` command)
+- No pathfinding plugin by default (basic movement only)
+- Combat is basic melee attacks (no advanced PvP logic)
+- GUI is client-side only (no user authentication)
+
+## Future Enhancements
+
+- Add mineflayer-pathfinder for advanced navigation
+- Implement PvP combat strategies
+- Add match creation from the testing client
+- Support for uploading custom bot scripts
+- Replay system for recorded matches
+
+## License
+
+Part of the BlockWarriors monorepo.

--- a/apps/mineflayer-tester/package.json
+++ b/apps/mineflayer-tester/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "mineflayer-tester",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Mineflayer bot testing client for BlockWarriors",
+  "engines": {
+    "node": ">=20.9.0"
+  },
+  "scripts": {
+    "dev": "PORT=3001 node src/index.js",
+    "start": "node src/index.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "minecraft-data": "^3.0.0",
+    "mineflayer": "^4.20.1",
+    "mineflayer-pathfinder": "^2.4.5",
+    "mineflayer-pvp": "^1.3.2",
+    "socket.io": "^4.7.2"
+  },
+  "optionalDependencies": {
+    "prismarine-viewer": "^1.24.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0"
+  }
+}

--- a/apps/mineflayer-tester/src/bot-instance.js
+++ b/apps/mineflayer-tester/src/bot-instance.js
@@ -1,0 +1,392 @@
+import mineflayer from 'mineflayer';
+import pathfinderPlugin from 'mineflayer-pathfinder';
+import pvpPlugin from 'mineflayer-pvp';
+import { EventEmitter } from 'events';
+
+const { pathfinder, Movements, goals } = pathfinderPlugin;
+const { plugin: pvp } = pvpPlugin;
+
+// Try to import prismarine-viewer, but make it optional
+let mineflayerViewer = null;
+try {
+  const prismarineViewer = await import('prismarine-viewer');
+  mineflayerViewer = prismarineViewer.mineflayer;
+} catch (e) {
+  console.log('prismarine-viewer not available (requires canvas). 3D viewer will be disabled.');
+}
+
+/**
+ * Represents a single Mineflayer bot instance
+ */
+export class BotInstance extends EventEmitter {
+  constructor(id, username, viewerPort) {
+    super();
+    this.id = id;
+    this.username = username;
+    this.viewerPort = viewerPort;
+    this.bot = null;
+    this.viewer = null;
+    this.status = 'disconnected'; // disconnected, connecting, connected, error
+    this.token = null;
+    this.matchId = null;
+    this.teamId = null;
+    this.attacking = false;
+    this.following = false;
+  }
+
+  /**
+   * Connect the bot to the Minecraft server with a token
+   */
+  async connect(token) {
+    this.token = token;
+    this.status = 'connecting';
+    this.emit('status', { id: this.id, status: 'connecting', message: 'Connecting to server...' });
+
+    try {
+      // Connect to BlockWarriors server
+      this.bot = mineflayer.createBot({
+        host: 'mcpanel.blockwarriors.ai',
+        port: 25565,
+        username: this.username,
+        auth: 'offline', // Offline mode - authentication via token
+        version: false, // Auto-detect version
+      });
+
+      // Load plugins
+      this.bot.loadPlugin(pathfinder);
+      this.bot.loadPlugin(pvp);
+
+      this.setupEventHandlers();
+    } catch (error) {
+      this.status = 'error';
+      this.emit('error', { id: this.id, error: error.message });
+    }
+  }
+
+  /**
+   * Set up event handlers for the bot
+   */
+  setupEventHandlers() {
+    this.bot.on('login', () => {
+      this.status = 'connected';
+      this.emit('log', { id: this.id, level: 'info', message: `Bot logged in as ${this.bot.username}` });
+
+      // Send login command with token
+      setTimeout(() => {
+        this.bot.chat(`/login ${this.token}`);
+        this.emit('log', { id: this.id, level: 'info', message: `Sent login command with token` });
+      }, 1000);
+    });
+
+    this.bot.on('spawn', () => {
+      this.emit('log', { id: this.id, level: 'success', message: 'Bot spawned in world' });
+
+      // Set up pathfinder movements
+      const defaultMove = new Movements(this.bot);
+      defaultMove.canDig = false; // Don't break blocks in PvP
+      defaultMove.allowSprinting = true;
+      this.bot.pathfinder.setMovements(defaultMove);
+
+      // Initialize viewer
+      this.initializeViewer();
+
+      this.emit('status', {
+        id: this.id,
+        status: 'connected',
+        position: this.bot.entity.position,
+        health: this.bot.health,
+        food: this.bot.food,
+        viewerUrl: `http://localhost:${this.viewerPort}`
+      });
+    });
+
+    this.bot.on('chat', (username, message) => {
+      this.emit('log', { id: this.id, level: 'chat', message: `<${username}> ${message}` });
+
+      // Parse server responses for login confirmation
+      if (message.includes('Successfully logged in') || message.includes('authenticated')) {
+        this.emit('log', { id: this.id, level: 'success', message: 'Authentication successful!' });
+      }
+    });
+
+    this.bot.on('whisper', (username, message) => {
+      this.emit('log', { id: this.id, level: 'whisper', message: `[${username} -> me] ${message}` });
+    });
+
+    this.bot.on('error', (err) => {
+      this.status = 'error';
+      this.emit('error', { id: this.id, error: err.message });
+      this.emit('log', { id: this.id, level: 'error', message: `Error: ${err.message}` });
+    });
+
+    this.bot.on('kicked', (reason) => {
+      this.status = 'disconnected';
+      this.emit('log', { id: this.id, level: 'error', message: `Kicked: ${reason}` });
+    });
+
+    this.bot.on('end', () => {
+      this.status = 'disconnected';
+      this.emit('log', { id: this.id, level: 'info', message: 'Disconnected from server' });
+      this.emit('status', { id: this.id, status: 'disconnected' });
+      if (this.viewer) {
+        this.viewer.close();
+        this.viewer = null;
+      }
+    });
+
+    this.bot.on('death', () => {
+      this.emit('log', { id: this.id, level: 'error', message: 'Bot died!' });
+      this.stopAttack();
+      this.stopFollow();
+    });
+
+    this.bot.on('health', () => {
+      this.emit('status', {
+        id: this.id,
+        health: this.bot.health,
+        food: this.bot.food
+      });
+    });
+
+    this.bot.on('physicsTick', () => {
+      // Update position periodically (throttled in manager)
+      if (this.bot.entity) {
+        this.emit('position', {
+          id: this.id,
+          position: this.bot.entity.position,
+          velocity: this.bot.entity.velocity,
+          yaw: this.bot.entity.yaw,
+          pitch: this.bot.entity.pitch
+        });
+      }
+    });
+
+    // PvP stop event
+    this.bot.on('stoppedAttacking', () => {
+      this.attacking = false;
+      this.emit('log', { id: this.id, level: 'info', message: 'Stopped attacking' });
+    });
+
+    // Pathfinder events
+    this.bot.on('path_update', (r) => {
+      const nodesPerTick = (r.visitedNodes * 50 / r.time).toFixed(2);
+      this.emit('log', {
+        id: this.id,
+        level: 'info',
+        message: `Pathfinding: ${r.visitedNodes} nodes, ${r.time.toFixed(2)}ms (${nodesPerTick} nodes/tick)`
+      });
+    });
+
+    this.bot.on('goal_reached', () => {
+      this.emit('log', { id: this.id, level: 'success', message: 'Goal reached!' });
+    });
+
+    this.bot.on('path_reset', (reason) => {
+      this.emit('log', { id: this.id, level: 'warning', message: `Path reset: ${reason}` });
+    });
+  }
+
+  /**
+   * Initialize prismarine-viewer for visual observability
+   */
+  initializeViewer() {
+    if (!mineflayerViewer) {
+      this.emit('log', {
+        id: this.id,
+        level: 'info',
+        message: '3D viewer not available (prismarine-viewer requires canvas)'
+      });
+      return;
+    }
+
+    try {
+      this.viewer = mineflayerViewer(this.bot, {
+        port: this.viewerPort,
+        firstPerson: true,
+        viewDistance: 6
+      });
+      this.emit('log', {
+        id: this.id,
+        level: 'success',
+        message: `Viewer available at http://localhost:${this.viewerPort}`
+      });
+    } catch (error) {
+      this.emit('log', {
+        id: this.id,
+        level: 'warning',
+        message: `Failed to initialize viewer: ${error.message}`
+      });
+    }
+  }
+
+  /**
+   * Send a chat message
+   */
+  chat(message) {
+    if (!this.bot || this.status !== 'connected') {
+      this.emit('error', { id: this.id, error: 'Bot is not connected' });
+      return;
+    }
+    this.bot.chat(message);
+    this.emit('log', { id: this.id, level: 'info', message: `Sent: ${message}` });
+  }
+
+  /**
+   * Attack a target player using mineflayer-pvp
+   */
+  async killPlayer(targetUsername) {
+    if (!this.bot || this.status !== 'connected') {
+      this.emit('error', { id: this.id, error: 'Bot is not connected' });
+      return;
+    }
+
+    const targetPlayer = this.bot.players[targetUsername];
+    if (!targetPlayer || !targetPlayer.entity) {
+      this.emit('log', { id: this.id, level: 'error', message: `Player ${targetUsername} not found` });
+      return;
+    }
+
+    this.attacking = true;
+    this.bot.pvp.attack(targetPlayer.entity);
+    this.emit('log', { id: this.id, level: 'info', message: `Attacking ${targetUsername}` });
+  }
+
+  /**
+   * Stop attacking current target
+   */
+  stopAttack() {
+    if (!this.bot || this.status !== 'connected') return;
+
+    this.bot.pvp.stop();
+    this.attacking = false;
+    this.emit('log', { id: this.id, level: 'info', message: 'Stopped attacking' });
+  }
+
+  /**
+   * Follow a player using pathfinder
+   */
+  followPlayer(targetUsername) {
+    if (!this.bot || this.status !== 'connected') {
+      this.emit('error', { id: this.id, error: 'Bot is not connected' });
+      return;
+    }
+
+    if (!targetUsername) {
+      this.stopFollow();
+      return;
+    }
+
+    const targetPlayer = this.bot.players[targetUsername];
+    if (!targetPlayer || !targetPlayer.entity) {
+      this.emit('log', { id: this.id, level: 'error', message: `Player ${targetUsername} not found` });
+      return;
+    }
+
+    this.following = true;
+    const goal = new goals.GoalFollow(targetPlayer.entity, 2);
+    this.bot.pathfinder.setGoal(goal, true); // true = dynamic goal
+    this.emit('log', { id: this.id, level: 'info', message: `Following ${targetUsername}` });
+  }
+
+  /**
+   * Stop following
+   */
+  stopFollow() {
+    if (!this.bot || this.status !== 'connected') return;
+
+    this.following = false;
+    this.bot.pathfinder.setGoal(null);
+    this.emit('log', { id: this.id, level: 'info', message: 'Stopped following' });
+  }
+
+  /**
+   * Move to specific coordinates using pathfinder
+   */
+  moveTo(x, y, z) {
+    if (!this.bot || this.status !== 'connected') {
+      this.emit('error', { id: this.id, error: 'Bot is not connected' });
+      return;
+    }
+
+    const goal = new goals.GoalNear(x, y, z, 1);
+    this.bot.pathfinder.setGoal(goal);
+    this.emit('log', { id: this.id, level: 'info', message: `Moving to (${Math.floor(x)}, ${Math.floor(y)}, ${Math.floor(z)})` });
+  }
+
+  /**
+   * Move relative to current position (for GUI controls)
+   */
+  moveRelative(dx, dz) {
+    if (!this.bot || this.status !== 'connected') {
+      this.emit('error', { id: this.id, error: 'Bot is not connected' });
+      return;
+    }
+
+    const pos = this.bot.entity.position;
+    this.moveTo(pos.x + dx, pos.y, pos.z + dz);
+  }
+
+  /**
+   * Look at coordinates
+   */
+  lookAt(x, y, z) {
+    if (!this.bot || this.status !== 'connected') return;
+
+    const target = this.bot.vec3(x, y, z);
+    this.bot.lookAt(target);
+  }
+
+  /**
+   * Get current bot state
+   */
+  getState() {
+    if (!this.bot || this.status !== 'connected') {
+      return {
+        id: this.id,
+        username: this.username,
+        status: this.status,
+        token: this.token ? '***' : null,
+        viewerPort: this.viewerPort
+      };
+    }
+
+    const pos = this.bot.entity?.position;
+    return {
+      id: this.id,
+      username: this.username,
+      status: this.status,
+      token: this.token ? '***' : null,
+      position: pos ? { x: pos.x, y: pos.y, z: pos.z } : null,
+      health: this.bot.health,
+      food: this.bot.food,
+      gameMode: this.bot.game?.gameMode,
+      dimension: this.bot.game?.dimension,
+      players: Object.keys(this.bot.players).filter(p => p !== this.bot.username),
+      viewerPort: this.viewerPort,
+      viewerUrl: `http://localhost:${this.viewerPort}`,
+      attacking: this.attacking,
+      following: this.following,
+      yaw: this.bot.entity?.yaw,
+      pitch: this.bot.entity?.pitch
+    };
+  }
+
+  /**
+   * Disconnect the bot
+   */
+  disconnect() {
+    if (this.bot) {
+      this.bot.pvp?.stop();
+      this.bot.pathfinder?.setGoal(null);
+      this.bot.quit();
+      this.bot = null;
+    }
+    if (this.viewer) {
+      this.viewer.close();
+      this.viewer = null;
+    }
+    this.status = 'disconnected';
+    this.attacking = false;
+    this.following = false;
+  }
+}

--- a/apps/mineflayer-tester/src/bot-manager.js
+++ b/apps/mineflayer-tester/src/bot-manager.js
@@ -1,0 +1,210 @@
+import { BotInstance } from './bot-instance.js';
+import { EventEmitter } from 'events';
+
+/**
+ * Manages multiple bot instances
+ */
+export class BotManager extends EventEmitter {
+  constructor() {
+    super();
+    this.bots = new Map(); // id -> BotInstance
+    this.nextId = 1;
+    this.nextViewerPort = 3010; // Start viewer ports from 3010
+    this.positionUpdateThrottle = new Map(); // id -> last update timestamp
+  }
+
+  /**
+   * Create a new bot
+   */
+  createBot(username) {
+    const id = this.nextId++;
+    const viewerPort = this.nextViewerPort++;
+    const bot = new BotInstance(id, username, viewerPort);
+
+    // Forward all bot events to manager
+    bot.on('log', (data) => this.emit('log', data));
+    bot.on('error', (data) => this.emit('error', data));
+    bot.on('status', (data) => this.emit('status', data));
+
+    // Throttle position updates (only send every 500ms)
+    bot.on('position', (data) => {
+      const lastUpdate = this.positionUpdateThrottle.get(id) || 0;
+      const now = Date.now();
+      if (now - lastUpdate > 500) {
+        this.positionUpdateThrottle.set(id, now);
+        this.emit('position', data);
+      }
+    });
+
+    this.bots.set(id, bot);
+    this.emit('bot-created', { id, username });
+    this.emit('log', { id, level: 'info', message: `Bot created: ${username}` });
+
+    return id;
+  }
+
+  /**
+   * Connect a bot with a token
+   */
+  async connectBot(id, token) {
+    const bot = this.bots.get(id);
+    if (!bot) {
+      throw new Error(`Bot ${id} not found`);
+    }
+
+    await bot.connect(token);
+  }
+
+  /**
+   * Send a chat message from a bot
+   */
+  chatAsBot(id, message) {
+    const bot = this.bots.get(id);
+    if (!bot) {
+      throw new Error(`Bot ${id} not found`);
+    }
+
+    bot.chat(message);
+  }
+
+  /**
+   * Make a bot attack a target player
+   */
+  killPlayer(botId, targetUsername) {
+    const bot = this.bots.get(botId);
+    if (!bot) {
+      throw new Error(`Bot ${botId} not found`);
+    }
+
+    bot.killPlayer(targetUsername);
+  }
+
+  /**
+   * Stop a bot from attacking
+   */
+  stopAttack(botId) {
+    const bot = this.bots.get(botId);
+    if (!bot) {
+      throw new Error(`Bot ${botId} not found`);
+    }
+
+    bot.stopAttack();
+  }
+
+  /**
+   * Make a bot follow a player
+   */
+  followPlayer(botId, targetUsername) {
+    const bot = this.bots.get(botId);
+    if (!bot) {
+      throw new Error(`Bot ${botId} not found`);
+    }
+
+    bot.followPlayer(targetUsername);
+  }
+
+  /**
+   * Make a bot move to coordinates
+   */
+  moveTo(botId, x, y, z) {
+    const bot = this.bots.get(botId);
+    if (!bot) {
+      throw new Error(`Bot ${botId} not found`);
+    }
+
+    bot.moveTo(x, y, z);
+  }
+
+  /**
+   * Make a bot move relative to current position
+   */
+  moveRelative(botId, dx, dz) {
+    const bot = this.bots.get(botId);
+    if (!bot) {
+      throw new Error(`Bot ${botId} not found`);
+    }
+
+    bot.moveRelative(dx, dz);
+  }
+
+  /**
+   * Stop a bot from following
+   */
+  stopFollow(botId) {
+    const bot = this.bots.get(botId);
+    if (!bot) {
+      throw new Error(`Bot ${botId} not found`);
+    }
+
+    bot.stopFollow();
+  }
+
+  /**
+   * Get all bot states
+   */
+  getAllStates() {
+    const states = [];
+    for (const [id, bot] of this.bots.entries()) {
+      states.push(bot.getState());
+    }
+    return states;
+  }
+
+  /**
+   * Get a specific bot state
+   */
+  getBotState(id) {
+    const bot = this.bots.get(id);
+    if (!bot) {
+      throw new Error(`Bot ${id} not found`);
+    }
+
+    return bot.getState();
+  }
+
+  /**
+   * Disconnect a bot
+   */
+  disconnectBot(id) {
+    const bot = this.bots.get(id);
+    if (!bot) {
+      throw new Error(`Bot ${id} not found`);
+    }
+
+    bot.disconnect();
+  }
+
+  /**
+   * Remove a bot completely
+   */
+  removeBot(id) {
+    const bot = this.bots.get(id);
+    if (!bot) {
+      throw new Error(`Bot ${id} not found`);
+    }
+
+    bot.disconnect();
+    this.bots.delete(id);
+    this.positionUpdateThrottle.delete(id);
+    this.emit('bot-removed', { id });
+    this.emit('log', { id, level: 'info', message: `Bot removed` });
+  }
+
+  /**
+   * Disconnect all bots
+   */
+  disconnectAll() {
+    for (const [id, bot] of this.bots.entries()) {
+      bot.disconnect();
+    }
+  }
+
+  /**
+   * Remove all bots
+   */
+  removeAll() {
+    for (const id of this.bots.keys()) {
+      this.removeBot(id);
+    }
+  }
+}

--- a/apps/mineflayer-tester/src/index.js
+++ b/apps/mineflayer-tester/src/index.js
@@ -1,0 +1,5 @@
+import { createAppServer } from './server.js';
+
+const PORT = process.env.PORT || 3000;
+
+createAppServer(PORT);

--- a/apps/mineflayer-tester/src/public/app.js
+++ b/apps/mineflayer-tester/src/public/app.js
@@ -1,0 +1,629 @@
+class MineflayerTestingClient {
+  constructor() {
+    this.socket = null;
+    this.bots = [];
+    this.selectedBotId = null;
+    this.maxLogs = 1000;
+    this.minimapScale = 10; // 1 pixel = 10 blocks
+    this.minimapCenter = { x: 0, z: 0 };
+    this.init();
+  }
+
+  async init() {
+    this.setupSocket();
+    this.setupMinimap();
+    await this.loadBots();
+    this.startMinimapRenderLoop();
+  }
+
+  setupSocket() {
+    this.socket = io();
+
+    this.socket.on('connect', () => {
+      this.addLog('info', 'Connected to server');
+    });
+
+    this.socket.on('disconnect', () => {
+      this.addLog('error', 'Disconnected from server');
+    });
+
+    this.socket.on('log', (data) => {
+      this.addLog(data.level, `[Bot ${data.id}] ${data.message}`);
+    });
+
+    this.socket.on('error', (data) => {
+      this.addLog('error', `[Bot ${data.id}] ERROR: ${data.error}`);
+    });
+
+    this.socket.on('status', (data) => {
+      this.updateBotStatus(data);
+    });
+
+    this.socket.on('position', (data) => {
+      this.updateBotPosition(data);
+    });
+
+    this.socket.on('bots-update', (bots) => {
+      this.bots = bots;
+      this.renderBots();
+      this.updateBotSelector();
+      this.renderMinimap();
+    });
+  }
+
+  setupMinimap() {
+    const canvas = document.getElementById('minimap');
+    this.minimapCanvas = canvas;
+    this.minimapCtx = canvas.getContext('2d');
+  }
+
+  startMinimapRenderLoop() {
+    setInterval(() => this.renderMinimap(), 100); // Update 10 times per second
+  }
+
+  renderMinimap() {
+    const ctx = this.minimapCtx;
+    const canvas = this.minimapCanvas;
+    const width = canvas.width;
+    const height = canvas.height;
+
+    // Clear canvas
+    ctx.fillStyle = '#1a2332';
+    ctx.fillRect(0, 0, width, height);
+
+    // Draw grid
+    ctx.strokeStyle = '#2d3748';
+    ctx.lineWidth = 1;
+
+    const gridSize = 50; // Grid lines every 50 blocks
+    const gridPixels = gridSize / this.minimapScale;
+
+    // Calculate offset for grid based on center
+    const offsetX = (this.minimapCenter.x % gridSize) / this.minimapScale;
+    const offsetZ = (this.minimapCenter.z % gridSize) / this.minimapScale;
+
+    // Vertical lines
+    for (let x = offsetX; x < width; x += gridPixels) {
+      ctx.beginPath();
+      ctx.moveTo(x, 0);
+      ctx.lineTo(x, height);
+      ctx.stroke();
+    }
+
+    // Horizontal lines
+    for (let z = offsetZ; z < height; z += gridPixels) {
+      ctx.beginPath();
+      ctx.moveTo(0, z);
+      ctx.lineTo(width, z);
+      ctx.stroke();
+    }
+
+    // Draw center cross
+    ctx.strokeStyle = '#4a5568';
+    ctx.lineWidth = 2;
+    ctx.beginPath();
+    ctx.moveTo(width / 2, height / 2 - 10);
+    ctx.lineTo(width / 2, height / 2 + 10);
+    ctx.moveTo(width / 2 - 10, height / 2);
+    ctx.lineTo(width / 2 + 10, height / 2);
+    ctx.stroke();
+
+    // Draw bots
+    const connectedBots = this.bots.filter(b => b.status === 'connected' && b.position);
+
+    connectedBots.forEach((bot, index) => {
+      const colors = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'];
+      const color = colors[index % colors.length];
+
+      const screenX = width / 2 + (bot.position.x - this.minimapCenter.x) / this.minimapScale;
+      const screenZ = height / 2 + (bot.position.z - this.minimapCenter.z) / this.minimapScale;
+
+      // Draw bot circle
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.arc(screenX, screenZ, 6, 0, Math.PI * 2);
+      ctx.fill();
+
+      // Draw bot direction indicator (based on yaw)
+      if (bot.yaw !== undefined) {
+        const angle = -bot.yaw; // Negative because canvas Y is inverted
+        const indicatorLength = 12;
+        const endX = screenX + Math.cos(angle) * indicatorLength;
+        const endZ = screenZ + Math.sin(angle) * indicatorLength;
+
+        ctx.strokeStyle = color;
+        ctx.lineWidth = 2;
+        ctx.beginPath();
+        ctx.moveTo(screenX, screenZ);
+        ctx.lineTo(endX, endZ);
+        ctx.stroke();
+      }
+
+      // Draw bot label
+      ctx.fillStyle = '#fff';
+      ctx.font = '11px monospace';
+      ctx.fillText(bot.username, screenX + 10, screenZ + 4);
+    });
+
+    // Draw scale indicator
+    ctx.fillStyle = '#94a3b8';
+    ctx.font = '12px monospace';
+    ctx.fillText(`1:${this.minimapScale}`, 10, height - 10);
+  }
+
+  centerMinimap() {
+    const connectedBots = this.bots.filter(b => b.status === 'connected' && b.position);
+
+    if (connectedBots.length === 0) {
+      this.minimapCenter = { x: 0, z: 0 };
+      return;
+    }
+
+    // Calculate average position
+    let sumX = 0;
+    let sumZ = 0;
+
+    connectedBots.forEach(bot => {
+      sumX += bot.position.x;
+      sumZ += bot.position.z;
+    });
+
+    this.minimapCenter = {
+      x: sumX / connectedBots.length,
+      z: sumZ / connectedBots.length
+    };
+
+    this.renderMinimap();
+  }
+
+  async loadBots() {
+    try {
+      const response = await fetch('/api/bots');
+      const data = await response.json();
+      if (data.success) {
+        this.bots = data.bots;
+        this.renderBots();
+        this.updateBotSelector();
+      }
+    } catch (error) {
+      this.addLog('error', `Failed to load bots: ${error.message}`);
+    }
+  }
+
+  updateBotSelector() {
+    const select = document.getElementById('selected-bot');
+    const currentValue = select.value;
+
+    // Keep track of the current selection
+    const selectedBot = currentValue ? parseInt(currentValue) : null;
+
+    // Rebuild options
+    select.innerHTML = '<option value="">Select a bot...</option>';
+
+    this.bots.forEach(bot => {
+      if (bot.status === 'connected') {
+        const option = document.createElement('option');
+        option.value = bot.id;
+        option.textContent = bot.username;
+        if (bot.id === selectedBot) {
+          option.selected = true;
+        }
+        select.appendChild(option);
+      }
+    });
+  }
+
+  selectBot() {
+    const select = document.getElementById('selected-bot');
+    this.selectedBotId = select.value ? parseInt(select.value) : null;
+  }
+
+  renderBots() {
+    const container = document.getElementById('bots-list');
+
+    if (this.bots.length === 0) {
+      container.innerHTML = '<p class="empty-state">No bots created yet. Click "Add Bot" to get started.</p>';
+      return;
+    }
+
+    container.innerHTML = this.bots.map(bot => this.renderBotCard(bot)).join('');
+  }
+
+  renderBotCard(bot) {
+    const statusClass = `status-${bot.status}`;
+    const isConnected = bot.status === 'connected';
+    const canConnect = bot.status === 'disconnected';
+
+    let infoHtml = '';
+    if (isConnected) {
+      infoHtml = `
+        <div class="bot-info">
+          ${bot.health !== undefined ? `<div class="bot-info-row"><span class="bot-info-label">Health:</span><span>${bot.health.toFixed(1)}/20</span></div>` : ''}
+          ${bot.food !== undefined ? `<div class="bot-info-row"><span class="bot-info-label">Food:</span><span>${bot.food}/20</span></div>` : ''}
+          ${bot.position ? `<div class="bot-info-row"><span class="bot-info-label">Position:</span><span>(${Math.floor(bot.position.x)}, ${Math.floor(bot.position.y)}, ${Math.floor(bot.position.z)})</span></div>` : ''}
+          ${bot.players && bot.players.length > 0 ? `<div class="bot-info-row"><span class="bot-info-label">Players:</span><span>${bot.players.length}</span></div>` : ''}
+          ${bot.attacking ? '<div class="bot-info-row"><span class="bot-info-label">Status:</span><span style="color: #ef4444">ATTACKING</span></div>' : ''}
+          ${bot.following ? '<div class="bot-info-row"><span class="bot-info-label">Status:</span><span style="color: #3b82f6">FOLLOWING</span></div>' : ''}
+          ${bot.viewerUrl ? `<a href="${bot.viewerUrl}" target="_blank" class="bot-viewer-link">🎮 Open 3D Viewer</a>` : ''}
+        </div>
+      `;
+    }
+
+    const actions = isConnected ? `
+      <button class="btn btn-secondary" onclick="app.showChatDialog(${bot.id})">Chat</button>
+      <button class="btn btn-secondary" onclick="app.showKillPlayerDialog(${bot.id})">Attack</button>
+      <button class="btn btn-secondary" onclick="app.showFollowDialog(${bot.id})">Follow</button>
+      <button class="btn btn-secondary" onclick="app.selectBotForMovement(${bot.id})">Control</button>
+      <button class="btn btn-danger" onclick="app.disconnectBot(${bot.id})">Disconnect</button>
+      <button class="btn btn-danger" onclick="app.removeBot(${bot.id})">Remove</button>
+    ` : canConnect ? `
+      <button class="btn btn-primary" onclick="app.showConnectBotDialog(${bot.id})">Connect</button>
+      <button class="btn btn-danger" onclick="app.removeBot(${bot.id})">Remove</button>
+    ` : `
+      <button class="btn btn-danger" onclick="app.removeBot(${bot.id})">Remove</button>
+    `;
+
+    return `
+      <div class="bot-card" id="bot-${bot.id}">
+        <div class="bot-header">
+          <span class="bot-name">${bot.username}</span>
+          <span class="bot-status ${statusClass}">${bot.status}</span>
+        </div>
+        ${infoHtml}
+        <div class="bot-actions">
+          ${actions}
+        </div>
+      </div>
+    `;
+  }
+
+  selectBotForMovement(botId) {
+    const select = document.getElementById('selected-bot');
+    select.value = botId;
+    this.selectedBotId = botId;
+    this.addLog('info', `Selected Bot ${botId} for movement control`);
+  }
+
+  updateBotStatus(data) {
+    const bot = this.bots.find(b => b.id === data.id);
+    if (bot) {
+      Object.assign(bot, data);
+      this.renderBots();
+      this.updateBotSelector();
+    }
+  }
+
+  updateBotPosition(data) {
+    const bot = this.bots.find(b => b.id === data.id);
+    if (bot) {
+      bot.position = data.position;
+      bot.yaw = data.yaw;
+      bot.pitch = data.pitch;
+      // Position rendering handled by minimap loop
+    }
+  }
+
+  // Movement Controls
+  moveBot(dx, dz) {
+    if (!this.selectedBotId) {
+      this.addLog('warning', 'Please select a bot first');
+      return;
+    }
+
+    fetch(`/api/bots/${this.selectedBotId}/move-relative`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ dx, dz })
+    });
+  }
+
+  stopBot() {
+    if (!this.selectedBotId) {
+      this.addLog('warning', 'Please select a bot first');
+      return;
+    }
+
+    fetch(`/api/bots/${this.selectedBotId}/stop-follow`, {
+      method: 'POST'
+    });
+  }
+
+  quickStopFollow() {
+    if (!this.selectedBotId) {
+      this.addLog('warning', 'Please select a bot first');
+      return;
+    }
+
+    fetch(`/api/bots/${this.selectedBotId}/stop-follow`, {
+      method: 'POST'
+    });
+  }
+
+  // Dialog Management
+  showCreateBotDialog() {
+    document.getElementById('create-bot-modal').classList.add('active');
+    document.getElementById('bot-username').focus();
+  }
+
+  hideCreateBotDialog() {
+    document.getElementById('create-bot-modal').classList.remove('active');
+    document.getElementById('bot-username').value = '';
+  }
+
+  showConnectBotDialog(botId) {
+    document.getElementById('connect-bot-id').value = botId;
+    document.getElementById('connect-bot-modal').classList.add('active');
+    document.getElementById('bot-token').focus();
+  }
+
+  hideConnectBotDialog() {
+    document.getElementById('connect-bot-modal').classList.remove('active');
+    document.getElementById('bot-token').value = '';
+  }
+
+  showKillPlayerDialog(botId) {
+    document.getElementById('kill-bot-id').value = botId;
+    document.getElementById('kill-player-modal').classList.add('active');
+    document.getElementById('kill-target').focus();
+  }
+
+  hideKillPlayerDialog() {
+    document.getElementById('kill-player-modal').classList.remove('active');
+    document.getElementById('kill-target').value = '';
+  }
+
+  showChatDialog(botId) {
+    document.getElementById('chat-bot-id').value = botId;
+    document.getElementById('chat-modal').classList.add('active');
+    document.getElementById('chat-message').focus();
+  }
+
+  hideChatDialog() {
+    document.getElementById('chat-modal').classList.remove('active');
+    document.getElementById('chat-message').value = '';
+  }
+
+  showMoveDialog() {
+    if (!this.selectedBotId) {
+      this.addLog('warning', 'Please select a bot first');
+      return;
+    }
+
+    document.getElementById('move-bot-id').value = this.selectedBotId;
+    document.getElementById('move-modal').classList.add('active');
+    document.getElementById('move-x').focus();
+  }
+
+  hideMoveDialog() {
+    document.getElementById('move-modal').classList.remove('active');
+    document.getElementById('move-x').value = '';
+    document.getElementById('move-y').value = '';
+    document.getElementById('move-z').value = '';
+  }
+
+  showFollowDialog(botId) {
+    document.getElementById('follow-bot-id').value = botId;
+    document.getElementById('follow-modal').classList.add('active');
+    document.getElementById('follow-target').focus();
+  }
+
+  hideFollowDialog() {
+    document.getElementById('follow-modal').classList.remove('active');
+    document.getElementById('follow-target').value = '';
+  }
+
+  // API Calls
+  async createBot(event) {
+    event.preventDefault();
+    const username = document.getElementById('bot-username').value;
+
+    try {
+      const response = await fetch('/api/bots/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username })
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        this.addLog('success', `Bot created: ${username} (ID: ${data.botId})`);
+        this.hideCreateBotDialog();
+      } else {
+        this.addLog('error', `Failed to create bot: ${data.error}`);
+      }
+    } catch (error) {
+      this.addLog('error', `Failed to create bot: ${error.message}`);
+    }
+  }
+
+  async connectBot(event) {
+    event.preventDefault();
+    const botId = parseInt(document.getElementById('connect-bot-id').value);
+    const token = document.getElementById('bot-token').value;
+
+    try {
+      const response = await fetch(`/api/bots/${botId}/connect`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ token })
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        this.addLog('success', `Connecting bot ${botId}...`);
+        this.hideConnectBotDialog();
+      } else {
+        this.addLog('error', `Failed to connect bot: ${data.error}`);
+      }
+    } catch (error) {
+      this.addLog('error', `Failed to connect bot: ${error.message}`);
+    }
+  }
+
+  async disconnectBot(botId) {
+    try {
+      const response = await fetch(`/api/bots/${botId}/disconnect`, {
+        method: 'POST'
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        this.addLog('info', `Disconnecting bot ${botId}...`);
+      } else {
+        this.addLog('error', `Failed to disconnect bot: ${data.error}`);
+      }
+    } catch (error) {
+      this.addLog('error', `Failed to disconnect bot: ${error.message}`);
+    }
+  }
+
+  async removeBot(botId) {
+    if (!confirm('Are you sure you want to remove this bot?')) {
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/bots/${botId}`, {
+        method: 'DELETE'
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        this.addLog('info', `Bot ${botId} removed`);
+      } else {
+        this.addLog('error', `Failed to remove bot: ${data.error}`);
+      }
+    } catch (error) {
+      this.addLog('error', `Failed to remove bot: ${error.message}`);
+    }
+  }
+
+  async sendChat(event) {
+    event.preventDefault();
+    const botId = parseInt(document.getElementById('chat-bot-id').value);
+    const message = document.getElementById('chat-message').value;
+
+    try {
+      const response = await fetch(`/api/bots/${botId}/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message })
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        this.hideChatDialog();
+      } else {
+        this.addLog('error', `Failed to send chat: ${data.error}`);
+      }
+    } catch (error) {
+      this.addLog('error', `Failed to send chat: ${error.message}`);
+    }
+  }
+
+  async killPlayer(event) {
+    event.preventDefault();
+    const botId = parseInt(document.getElementById('kill-bot-id').value);
+    const target = document.getElementById('kill-target').value;
+
+    try {
+      const response = await fetch(`/api/bots/${botId}/kill`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target })
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        this.hideKillPlayerDialog();
+      } else {
+        this.addLog('error', `Failed to attack player: ${data.error}`);
+      }
+    } catch (error) {
+      this.addLog('error', `Failed to attack player: ${error.message}`);
+    }
+  }
+
+  async moveBotToCoords(event) {
+    event.preventDefault();
+    const botId = parseInt(document.getElementById('move-bot-id').value);
+    const x = parseFloat(document.getElementById('move-x').value);
+    const y = parseFloat(document.getElementById('move-y').value);
+    const z = parseFloat(document.getElementById('move-z').value);
+
+    try {
+      const response = await fetch(`/api/bots/${botId}/move`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ x, y, z })
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        this.hideMoveDialog();
+      } else {
+        this.addLog('error', `Failed to move bot: ${data.error}`);
+      }
+    } catch (error) {
+      this.addLog('error', `Failed to move bot: ${error.message}`);
+    }
+  }
+
+  async followPlayer(event) {
+    event.preventDefault();
+    const botId = parseInt(document.getElementById('follow-bot-id').value);
+    const target = document.getElementById('follow-target').value;
+
+    try {
+      const response = await fetch(`/api/bots/${botId}/follow`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ target })
+      });
+
+      const data = await response.json();
+      if (data.success) {
+        this.hideFollowDialog();
+      } else {
+        this.addLog('error', `Failed to follow player: ${data.error}`);
+      }
+    } catch (error) {
+      this.addLog('error', `Failed to follow player: ${error.message}`);
+    }
+  }
+
+  // Logging
+  addLog(level, message) {
+    const container = document.getElementById('logs-container');
+    const entry = document.createElement('p');
+    entry.className = `log-entry log-${level}`;
+
+    const timestamp = new Date().toLocaleTimeString();
+    entry.textContent = `[${timestamp}] ${message}`;
+
+    container.appendChild(entry);
+
+    // Limit log entries
+    while (container.children.length > this.maxLogs) {
+      container.removeChild(container.firstChild);
+    }
+
+    // Auto-scroll to bottom
+    container.scrollTop = container.scrollHeight;
+  }
+
+  clearLogs() {
+    const container = document.getElementById('logs-container');
+    container.innerHTML = '<p class="log-entry log-info">Logs cleared.</p>';
+  }
+}
+
+// Initialize app
+const app = new MineflayerTestingClient();
+
+// Close modals when clicking outside
+document.addEventListener('click', (e) => {
+  if (e.target.classList.contains('modal')) {
+    e.target.classList.remove('active');
+  }
+});

--- a/apps/mineflayer-tester/src/public/index.html
+++ b/apps/mineflayer-tester/src/public/index.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BlockWarriors Mineflayer Testing Client</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>BlockWarriors Mineflayer Testing Client</h1>
+            <p class="subtitle">Server: <code>mcpanel.blockwarriors.ai:25565</code></p>
+        </header>
+
+        <div class="main-content">
+            <!-- Left Panel: Bot Management -->
+            <div class="panel bots-panel">
+                <div class="panel-header">
+                    <h2>Bots</h2>
+                    <button class="btn btn-primary" onclick="app.showCreateBotDialog()">+ Add Bot</button>
+                </div>
+                <div class="bots-list" id="bots-list">
+                    <p class="empty-state">No bots created yet. Click "Add Bot" to get started.</p>
+                </div>
+            </div>
+
+            <!-- Middle Panel: Controls & Minimap -->
+            <div class="center-column">
+                <!-- Minimap -->
+                <div class="panel minimap-panel">
+                    <div class="panel-header">
+                        <h2>Minimap</h2>
+                        <button class="btn btn-secondary" onclick="app.centerMinimap()">Center</button>
+                    </div>
+                    <div class="minimap-container">
+                        <canvas id="minimap" width="400" height="400"></canvas>
+                        <div class="minimap-info" id="minimap-info">
+                            <span>Scale: <span id="minimap-scale">1:10</span></span>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Movement Controls -->
+                <div class="panel controls-panel">
+                    <div class="panel-header">
+                        <h2>Movement Controls</h2>
+                        <select id="selected-bot" onchange="app.selectBot()">
+                            <option value="">Select a bot...</option>
+                        </select>
+                    </div>
+                    <div class="controls-container">
+                        <div class="movement-grid">
+                            <button class="move-btn" onclick="app.moveBot(-10, -10)">↖</button>
+                            <button class="move-btn" onclick="app.moveBot(0, -10)">↑</button>
+                            <button class="move-btn" onclick="app.moveBot(10, -10)">↗</button>
+                            <button class="move-btn" onclick="app.moveBot(-10, 0)">←</button>
+                            <button class="move-btn center" onclick="app.stopBot()">STOP</button>
+                            <button class="move-btn" onclick="app.moveBot(10, 0)">→</button>
+                            <button class="move-btn" onclick="app.moveBot(-10, 10)">↙</button>
+                            <button class="move-btn" onclick="app.moveBot(0, 10)">↓</button>
+                            <button class="move-btn" onclick="app.moveBot(10, 10)">↘</button>
+                        </div>
+                        <div class="control-actions">
+                            <button class="btn btn-secondary" onclick="app.showMoveDialog()">Go to XYZ</button>
+                            <button class="btn btn-danger" onclick="app.quickStopFollow()">Stop Follow</button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Right Panel: Logs -->
+            <div class="panel logs-panel">
+                <div class="panel-header">
+                    <h2>Activity Log</h2>
+                    <button class="btn btn-secondary" onclick="app.clearLogs()">Clear</button>
+                </div>
+                <div class="logs-container" id="logs-container">
+                    <p class="log-entry log-info">Welcome to the Mineflayer Testing Client!</p>
+                    <p class="log-entry log-info">Create a bot and connect it with a token to begin testing.</p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Create Bot Dialog -->
+    <div class="modal" id="create-bot-modal">
+        <div class="modal-content">
+            <h3>Create New Bot</h3>
+            <form onsubmit="app.createBot(event)">
+                <div class="form-group">
+                    <label for="bot-username">Username</label>
+                    <input type="text" id="bot-username" placeholder="Enter bot username" required>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="app.hideCreateBotDialog()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Create</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Connect Bot Dialog -->
+    <div class="modal" id="connect-bot-modal">
+        <div class="modal-content">
+            <h3>Connect Bot</h3>
+            <form onsubmit="app.connectBot(event)">
+                <input type="hidden" id="connect-bot-id">
+                <div class="form-group">
+                    <label for="bot-token">Token</label>
+                    <input type="text" id="bot-token" placeholder="Enter authentication token" required>
+                    <small>Get a token from a created match on the BlockWarriors dashboard</small>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="app.hideConnectBotDialog()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Connect</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Kill Player Dialog -->
+    <div class="modal" id="kill-player-modal">
+        <div class="modal-content">
+            <h3>Attack Player</h3>
+            <form onsubmit="app.killPlayer(event)">
+                <input type="hidden" id="kill-bot-id">
+                <div class="form-group">
+                    <label for="kill-target">Target Username</label>
+                    <input type="text" id="kill-target" placeholder="Enter player username" required>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="app.hideKillPlayerDialog()">Cancel</button>
+                    <button type="submit" class="btn btn-danger">Attack</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Chat Dialog -->
+    <div class="modal" id="chat-modal">
+        <div class="modal-content">
+            <h3>Send Chat Message</h3>
+            <form onsubmit="app.sendChat(event)">
+                <input type="hidden" id="chat-bot-id">
+                <div class="form-group">
+                    <label for="chat-message">Message</label>
+                    <input type="text" id="chat-message" placeholder="Enter message" required>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="app.hideChatDialog()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Send</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Move Dialog -->
+    <div class="modal" id="move-modal">
+        <div class="modal-content">
+            <h3>Move Bot</h3>
+            <form onsubmit="app.moveBotToCoords(event)">
+                <input type="hidden" id="move-bot-id">
+                <div class="form-group">
+                    <label for="move-x">X</label>
+                    <input type="number" id="move-x" placeholder="X coordinate" required>
+                </div>
+                <div class="form-group">
+                    <label for="move-y">Y</label>
+                    <input type="number" id="move-y" placeholder="Y coordinate" required>
+                </div>
+                <div class="form-group">
+                    <label for="move-z">Z</label>
+                    <input type="number" id="move-z" placeholder="Z coordinate" required>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="app.hideMoveDialog()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Move</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <!-- Follow Dialog -->
+    <div class="modal" id="follow-modal">
+        <div class="modal-content">
+            <h3>Follow Player</h3>
+            <form onsubmit="app.followPlayer(event)">
+                <input type="hidden" id="follow-bot-id">
+                <div class="form-group">
+                    <label for="follow-target">Target Username</label>
+                    <input type="text" id="follow-target" placeholder="Enter player username" required>
+                </div>
+                <div class="form-actions">
+                    <button type="button" class="btn btn-secondary" onclick="app.hideFollowDialog()">Cancel</button>
+                    <button type="submit" class="btn btn-primary">Follow</button>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <script src="/socket.io/socket.io.js"></script>
+    <script src="app.js"></script>
+</body>
+</html>

--- a/apps/mineflayer-tester/src/public/styles.css
+++ b/apps/mineflayer-tester/src/public/styles.css
@@ -1,0 +1,510 @@
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --bg-primary: #0f172a;
+    --bg-secondary: #1e293b;
+    --bg-tertiary: #334155;
+    --text-primary: #f8fafc;
+    --text-secondary: #cbd5e1;
+    --text-muted: #94a3b8;
+    --border: #475569;
+    --accent: #3b82f6;
+    --accent-hover: #2563eb;
+    --success: #10b981;
+    --danger: #ef4444;
+    --warning: #f59e0b;
+    --info: #06b6d4;
+}
+
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+.container {
+    max-width: 1800px;
+    margin: 0 auto;
+    padding: 20px;
+}
+
+/* Header */
+header {
+    margin-bottom: 30px;
+    text-align: center;
+}
+
+header h1 {
+    font-size: 2rem;
+    font-weight: 700;
+    margin-bottom: 8px;
+    background: linear-gradient(135deg, var(--accent), var(--info));
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    background-clip: text;
+}
+
+.subtitle {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+}
+
+.subtitle code {
+    background: var(--bg-secondary);
+    padding: 2px 8px;
+    border-radius: 4px;
+    color: var(--accent);
+    font-family: 'Monaco', 'Courier New', monospace;
+}
+
+/* Main Content - 3 Column Layout */
+.main-content {
+    display: grid;
+    grid-template-columns: 350px 1fr 450px;
+    gap: 20px;
+    height: calc(100vh - 150px);
+}
+
+.center-column {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+/* Panels */
+.panel {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    overflow: hidden;
+    display: flex;
+    flex-direction: column;
+}
+
+.panel-header {
+    padding: 16px 20px;
+    background: var(--bg-tertiary);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+}
+
+.panel-header h2 {
+    font-size: 1.125rem;
+    font-weight: 600;
+}
+
+.panel-header select {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    color: var(--text-primary);
+    padding: 6px 12px;
+    border-radius: 4px;
+    font-size: 0.875rem;
+    cursor: pointer;
+}
+
+/* Bots List */
+.bots-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+}
+
+.empty-state {
+    text-align: center;
+    color: var(--text-muted);
+    padding: 40px 20px;
+    font-size: 0.875rem;
+}
+
+.bot-card {
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    padding: 14px;
+    margin-bottom: 12px;
+}
+
+.bot-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.bot-name {
+    font-weight: 600;
+    font-size: 0.95rem;
+}
+
+.bot-status {
+    padding: 3px 10px;
+    border-radius: 12px;
+    font-size: 0.7rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+}
+
+.status-disconnected {
+    background: var(--bg-secondary);
+    color: var(--text-muted);
+}
+
+.status-connecting {
+    background: rgba(251, 191, 36, 0.2);
+    color: var(--warning);
+}
+
+.status-connected {
+    background: rgba(16, 185, 129, 0.2);
+    color: var(--success);
+}
+
+.status-error {
+    background: rgba(239, 68, 68, 0.2);
+    color: var(--danger);
+}
+
+.bot-info {
+    font-size: 0.8125rem;
+    color: var(--text-secondary);
+    margin-bottom: 10px;
+}
+
+.bot-info-row {
+    display: flex;
+    justify-content: space-between;
+    margin-bottom: 3px;
+}
+
+.bot-info-label {
+    color: var(--text-muted);
+}
+
+.bot-viewer-link {
+    display: inline-block;
+    margin-top: 6px;
+    padding: 4px 10px;
+    background: rgba(59, 130, 246, 0.2);
+    color: var(--accent);
+    text-decoration: none;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    transition: background 0.2s;
+}
+
+.bot-viewer-link:hover {
+    background: rgba(59, 130, 246, 0.3);
+}
+
+.bot-actions {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 6px;
+    margin-top: 10px;
+}
+
+.bot-actions button {
+    font-size: 0.75rem;
+    padding: 6px 10px;
+}
+
+/* Minimap */
+.minimap-panel {
+    flex: 1;
+}
+
+.minimap-container {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 20px;
+    position: relative;
+}
+
+#minimap {
+    border: 2px solid var(--border);
+    border-radius: 8px;
+    background: #1a2332;
+}
+
+.minimap-info {
+    margin-top: 12px;
+    font-size: 0.8125rem;
+    color: var(--text-muted);
+}
+
+/* Movement Controls */
+.controls-panel {
+    flex-shrink: 0;
+}
+
+.controls-container {
+    padding: 20px;
+}
+
+.movement-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 8px;
+    margin-bottom: 16px;
+}
+
+.move-btn {
+    padding: 16px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 1.25rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.move-btn:hover:not(:disabled) {
+    background: var(--border);
+    transform: translateY(-2px);
+}
+
+.move-btn:active:not(:disabled) {
+    transform: translateY(0);
+}
+
+.move-btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.move-btn.center {
+    background: var(--danger);
+    color: white;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.move-btn.center:hover:not(:disabled) {
+    background: #dc2626;
+}
+
+.control-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 8px;
+}
+
+/* Logs */
+.logs-container {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+    font-family: 'Monaco', 'Courier New', monospace;
+    font-size: 0.8125rem;
+    line-height: 1.6;
+}
+
+.log-entry {
+    margin-bottom: 4px;
+    padding: 4px 8px;
+    border-radius: 4px;
+    word-wrap: break-word;
+}
+
+.log-info {
+    color: var(--info);
+}
+
+.log-success {
+    color: var(--success);
+}
+
+.log-error {
+    color: var(--danger);
+    background: rgba(239, 68, 68, 0.1);
+}
+
+.log-warning {
+    color: var(--warning);
+}
+
+.log-chat {
+    color: var(--text-secondary);
+}
+
+.log-whisper {
+    color: #a78bfa;
+}
+
+/* Buttons */
+.btn {
+    padding: 10px 18px;
+    border: none;
+    border-radius: 6px;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.2s;
+    font-family: inherit;
+}
+
+.btn-primary {
+    background: var(--accent);
+    color: white;
+}
+
+.btn-primary:hover {
+    background: var(--accent-hover);
+}
+
+.btn-secondary {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+    border: 1px solid var(--border);
+}
+
+.btn-secondary:hover {
+    background: var(--border);
+}
+
+.btn-danger {
+    background: var(--danger);
+    color: white;
+}
+
+.btn-danger:hover {
+    background: #dc2626;
+}
+
+.btn:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+/* Modal */
+.modal {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 1000;
+    align-items: center;
+    justify-content: center;
+}
+
+.modal.active {
+    display: flex;
+}
+
+.modal-content {
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 24px;
+    max-width: 500px;
+    width: 90%;
+}
+
+.modal-content h3 {
+    font-size: 1.25rem;
+    margin-bottom: 20px;
+}
+
+.form-group {
+    margin-bottom: 16px;
+}
+
+.form-group label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text-secondary);
+}
+
+.form-group input,
+.form-group select {
+    width: 100%;
+    padding: 10px 12px;
+    background: var(--bg-tertiary);
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    color: var(--text-primary);
+    font-size: 0.875rem;
+    font-family: inherit;
+}
+
+.form-group input:focus,
+.form-group select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.form-group small {
+    display: block;
+    margin-top: 4px;
+    color: var(--text-muted);
+    font-size: 0.75rem;
+}
+
+.form-actions {
+    display: flex;
+    gap: 12px;
+    justify-content: flex-end;
+    margin-top: 24px;
+}
+
+/* Scrollbar */
+::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: var(--bg-secondary);
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: var(--text-muted);
+}
+
+/* Responsive */
+@media (max-width: 1400px) {
+    .main-content {
+        grid-template-columns: 300px 1fr 400px;
+    }
+}
+
+@media (max-width: 1024px) {
+    .main-content {
+        grid-template-columns: 1fr;
+        height: auto;
+    }
+
+    .panel {
+        height: 400px;
+    }
+
+    .minimap-panel,
+    .controls-panel {
+        height: 300px;
+    }
+}

--- a/apps/mineflayer-tester/src/server.js
+++ b/apps/mineflayer-tester/src/server.js
@@ -1,0 +1,220 @@
+import express from 'express';
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { BotManager } from './bot-manager.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export function createAppServer(port = 3000) {
+  const app = express();
+  const httpServer = createServer(app);
+  const io = new Server(httpServer);
+  const botManager = new BotManager();
+
+  // Serve static files
+  app.use(express.static(join(__dirname, 'public')));
+  app.use(express.json());
+
+  // API Routes
+  app.get('/api/bots', (req, res) => {
+    try {
+      const states = botManager.getAllStates();
+      res.json({ success: true, bots: states });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/create', (req, res) => {
+    try {
+      const { username } = req.body;
+      if (!username) {
+        return res.status(400).json({ success: false, error: 'Username is required' });
+      }
+
+      const id = botManager.createBot(username);
+      res.json({ success: true, botId: id });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/:id/connect', async (req, res) => {
+    try {
+      const { id } = req.params;
+      const { token } = req.body;
+
+      if (!token) {
+        return res.status(400).json({ success: false, error: 'Token is required' });
+      }
+
+      await botManager.connectBot(parseInt(id), token);
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/:id/disconnect', (req, res) => {
+    try {
+      const { id } = req.params;
+      botManager.disconnectBot(parseInt(id));
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.delete('/api/bots/:id', (req, res) => {
+    try {
+      const { id } = req.params;
+      botManager.removeBot(parseInt(id));
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/:id/chat', (req, res) => {
+    try {
+      const { id } = req.params;
+      const { message } = req.body;
+
+      if (!message) {
+        return res.status(400).json({ success: false, error: 'Message is required' });
+      }
+
+      botManager.chatAsBot(parseInt(id), message);
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/:id/kill', (req, res) => {
+    try {
+      const { id } = req.params;
+      const { target } = req.body;
+
+      if (!target) {
+        return res.status(400).json({ success: false, error: 'Target username is required' });
+      }
+
+      botManager.killPlayer(parseInt(id), target);
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/:id/stop-attack', (req, res) => {
+    try {
+      const { id } = req.params;
+      botManager.stopAttack(parseInt(id));
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/:id/follow', (req, res) => {
+    try {
+      const { id } = req.params;
+      const { target } = req.body;
+
+      botManager.followPlayer(parseInt(id), target);
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/:id/move', (req, res) => {
+    try {
+      const { id } = req.params;
+      const { x, y, z } = req.body;
+
+      if (x === undefined || y === undefined || z === undefined) {
+        return res.status(400).json({ success: false, error: 'x, y, z coordinates are required' });
+      }
+
+      botManager.moveTo(parseInt(id), parseFloat(x), parseFloat(y), parseFloat(z));
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/:id/move-relative', (req, res) => {
+    try {
+      const { id } = req.params;
+      const { dx, dz } = req.body;
+
+      if (dx === undefined || dz === undefined) {
+        return res.status(400).json({ success: false, error: 'dx, dz are required' });
+      }
+
+      botManager.moveRelative(parseInt(id), parseFloat(dx), parseFloat(dz));
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  app.post('/api/bots/:id/stop-follow', (req, res) => {
+    try {
+      const { id } = req.params;
+      botManager.stopFollow(parseInt(id));
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({ success: false, error: error.message });
+    }
+  });
+
+  // Socket.io connection
+  io.on('connection', (socket) => {
+    console.log('Client connected:', socket.id);
+
+    // Send initial state
+    socket.emit('bots-update', botManager.getAllStates());
+
+    // Forward all bot manager events to connected clients
+    const logHandler = (data) => socket.emit('log', data);
+    const errorHandler = (data) => socket.emit('error', data);
+    const statusHandler = (data) => {
+      socket.emit('status', data);
+      socket.emit('bots-update', botManager.getAllStates());
+    };
+    const positionHandler = (data) => socket.emit('position', data);
+    const botCreatedHandler = () => socket.emit('bots-update', botManager.getAllStates());
+    const botRemovedHandler = () => socket.emit('bots-update', botManager.getAllStates());
+
+    botManager.on('log', logHandler);
+    botManager.on('error', errorHandler);
+    botManager.on('status', statusHandler);
+    botManager.on('position', positionHandler);
+    botManager.on('bot-created', botCreatedHandler);
+    botManager.on('bot-removed', botRemovedHandler);
+
+    socket.on('disconnect', () => {
+      console.log('Client disconnected:', socket.id);
+      botManager.off('log', logHandler);
+      botManager.off('error', errorHandler);
+      botManager.off('status', statusHandler);
+      botManager.off('position', positionHandler);
+      botManager.off('bot-created', botCreatedHandler);
+      botManager.off('bot-removed', botRemovedHandler);
+    });
+  });
+
+  // Start server
+  httpServer.listen(port, () => {
+    console.log(`Mineflayer Testing Client running on http://localhost:${port}`);
+    console.log(`Connect to BlockWarriors at: play.blockwarriors.ai`);
+  });
+
+  return { app, httpServer, io, botManager };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -363,6 +363,43 @@
         "nodemon": "^3.1.9"
       }
     },
+    "apps/mineflayer-tester": {
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "^4.18.2",
+        "minecraft-data": "^3.0.0",
+        "mineflayer": "^4.20.1",
+        "mineflayer-pathfinder": "^2.4.5",
+        "mineflayer-pvp": "^1.3.2",
+        "socket.io": "^4.7.2"
+      },
+      "devDependencies": {
+        "@types/node": "^20.10.0"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "optionalDependencies": {
+        "prismarine-viewer": "^1.24.0"
+      }
+    },
+    "apps/mineflayer-tester/node_modules/@types/node": {
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "apps/mineflayer-tester/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "blockwarriors-next": {
       "version": "0.1.0",
       "extraneous": true,
@@ -473,6 +510,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@azure/msal-common": {
+      "version": "14.16.1",
+      "resolved": "https://registry.npmjs.org/@azure/msal-common/-/msal-common-14.16.1.tgz",
+      "integrity": "sha512-nyxsA6NA4SVKh5YyRpbSXiMr7oQbwark7JU9LMeg6tJYTSPyAGkdx61wPT4gyxZfxlSxMMEyAsWaubBlNyIa1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@azure/msal-node": {
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@azure/msal-node/-/msal-node-2.16.3.tgz",
+      "integrity": "sha512-CO+SE4weOsfJf+C5LM8argzvotrXw252/ZU6SM2Tz63fEblhH1uuVaaO4ISYFuN4Q6BhTo7I3qIdi8ydUQCqhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-common": "14.16.1",
+        "jsonwebtoken": "^9.0.0",
+        "uuid": "^8.3.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@azure/msal-node/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -5657,6 +5726,13 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
@@ -5673,6 +5749,15 @@
       "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
       "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
       "license": "MIT"
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
@@ -5753,6 +5838,15 @@
         "undici-types": "~7.16.0"
       }
     },
+    "node_modules/@types/node-rsa": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@types/node-rsa/-/node-rsa-1.1.4.tgz",
+      "integrity": "sha512-dB0ECel6JpMnq5ULvpUTunx3yNm8e/dIkv8Zu9p2c8me70xIRUUG3q+qXRwcSf9rN3oqamv4116iHy90dJGRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/parse-json": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -5788,6 +5882,15 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.22",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.22.tgz",
+      "integrity": "sha512-/FFhJpfCLAPwAcN3mFycNUa77ddnr8jTgF5VmSNetaemWB2cIlfCA9t0YTM3JAT0wOcv8D4tjPo7pkDhK3EJIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/ws": {
@@ -6377,6 +6480,47 @@
         "node": ">=16"
       }
     },
+    "node_modules/@xboxreplay/errors": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@xboxreplay/errors/-/errors-0.1.0.tgz",
+      "integrity": "sha512-Tgz1d/OIPDWPeyOvuL5+aai5VCcqObhPnlI3skQuf80GVF3k1I0lPCnGC+8Cm5PV9aLBT5m8qPcJoIUQ2U4y9g==",
+      "license": "MIT"
+    },
+    "node_modules/@xboxreplay/xboxlive-auth": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/@xboxreplay/xboxlive-auth/-/xboxlive-auth-3.3.3.tgz",
+      "integrity": "sha512-j0AU8pW10LM8O68CTZ5QHnvOjSsnPICy0oQcP7zyM7eWkDQ/InkiQiirQKsPn1XRYDl4ccNu0WM582s3UKwcBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@xboxreplay/errors": "^0.1.0",
+        "axios": "^0.21.1"
+      }
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -6400,6 +6544,12 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/aes-js": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.1.2.tgz",
+      "integrity": "sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==",
+      "license": "MIT"
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -6414,7 +6564,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -6521,6 +6670,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.9",
@@ -6665,6 +6820,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/asn1": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha512-6i37w/+EhlWlGUJff3T/Q8u1RGmP5wgbiwYnOnbOqvtrPxT63/sYFyP9RcpxtxGymtfA075IvmOnL7ycNOWl3w==",
+      "license": "MIT"
+    },
     "node_modules/asn1js": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/asn1js/-/asn1js-3.0.6.tgz",
@@ -6758,6 +6919,15 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.21.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.0"
       }
     },
     "node_modules/axobject-query": {
@@ -6874,6 +7044,15 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.25",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz",
@@ -6976,6 +7155,45 @@
       "resolved": "apps/blockwarriors-next",
       "link": true
     },
+    "node_modules/body-parser": {
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -7033,6 +7251,77 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/buffer-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-1.0.1.tgz",
+      "integrity": "sha512-QoV3ptgEaQpvVwbXdSO39iqPQTCxSF7A5U99AxbHYqUdCizL/lH2Z0A2y6nbZucxMEOtNyZfG2s6gsVugGpKkg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/buffer/node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/call-bind": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
@@ -7056,7 +7345,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -7070,7 +7358,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -7293,12 +7580,92 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/compression/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -7383,6 +7750,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
     "node_modules/core-js-compat": {
       "version": "3.46.0",
       "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.46.0.tgz",
@@ -7395,6 +7768,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/cosmiconfig": {
@@ -7766,6 +8152,25 @@
       "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7787,6 +8192,12 @@
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "license": "MIT"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
@@ -7833,7 +8244,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -7848,6 +8258,21 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -7890,6 +8315,41 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/endian-toggle": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/endian-toggle/-/endian-toggle-0.0.0.tgz",
+      "integrity": "sha512-ShfqhXeHRE4TmggSlHXG8CMGIcsOsqDw/GcoPcosToE59Rm9e4aXaMhEQf2kPBsBRrKem1bbOAv5gOKnkliMFQ==",
+      "license": "MIT"
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
     },
     "node_modules/engine.io-client": {
       "version": "6.6.3",
@@ -7949,6 +8409,44 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/error-ex": {
@@ -8033,7 +8531,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8043,7 +8540,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -8081,7 +8577,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -8740,17 +9235,104 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
       "license": "MIT"
     },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/express/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -8790,7 +9372,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -8864,6 +9445,39 @@
         "node": ">=8"
       }
     },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/finalhandler/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/finalhandler/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/find-root": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
@@ -8908,6 +9522,26 @@
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.5",
@@ -8954,6 +9588,15 @@
         "node": ">=12.20.0"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -8993,6 +9636,15 @@
         "react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/fs.realpath": {
@@ -9080,7 +9732,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -9114,7 +9765,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -9248,7 +9898,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9310,7 +9959,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -9373,6 +10021,26 @@
       "resolved": "https://registry.npmjs.org/http/-/http-0.0.1-security.tgz",
       "integrity": "sha512-RnDvP10Ty9FxqOtPZuxtebw1j4L/WiqNMDtuc1YMH1XQm5TgDRaR1G9u8upL6KD1bXHSp9eSXo/ED+8Q7FAr+g=="
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -9386,6 +10054,38 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -9439,7 +10139,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/input-otp": {
@@ -9474,6 +10173,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-array-buffer": {
@@ -10023,7 +10731,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
@@ -10046,6 +10753,28 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.2.tgz",
+      "integrity": "sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^3.2.2",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -10060,6 +10789,27 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.2.tgz",
+      "integrity": "sha512-eeH5JO+21J78qMvTIDdBXidBd6nG2kZjg5Ohz/1fpa28Z4CcsWUzJ1ZZyFq/3z3N17aZy+ZuBoHljASbL1WfOw==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {
@@ -10172,11 +10922,58 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.reduce": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "integrity": "sha512-6raRe2vxCYBhpBu+B+TtNGUzah+hQjVdu3E17wfusjyrXBka2nBS8OH/gjVZ5PvHOhWmIZTYri09Z6n/QfnNMw==",
       "license": "MIT"
     },
     "node_modules/loose-envify": {
@@ -10210,14 +11007,28 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/macaddress": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.5.3.tgz",
+      "integrity": "sha512-vGBKTA+jwM4KgjGZ+S/8/Mkj9rWzePyGY6jManXPGhiWu63RYwW8dKPyk5koP+8qNVhPhHgFa1y/MJ4wrjsNrg==",
+      "license": "MIT"
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/memoize-one": {
@@ -10226,6 +11037,15 @@
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
     },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -10233,6 +11053,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/micromatch": {
@@ -10246,6 +11075,241 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minecraft-data": {
+      "version": "3.101.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-3.101.0.tgz",
+      "integrity": "sha512-9kD2sbI9BvjQtN/ZlMkCdgaLJIHPXDGruMEJ0DOO29RB9sVDmSBLjDkH9PyRmlAye/WZlqk/1/b54vWq6ObzxQ==",
+      "license": "MIT"
+    },
+    "node_modules/minecraft-folder-path": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minecraft-folder-path/-/minecraft-folder-path-1.2.0.tgz",
+      "integrity": "sha512-qaUSbKWoOsH9brn0JQuBhxNAzTDMwrOXorwuRxdJKKKDYvZhtml+6GVCUrY5HRiEsieBEjCUnhVpDuQiKsiFaw==",
+      "license": "MIT"
+    },
+    "node_modules/minecraft-protocol": {
+      "version": "1.62.0",
+      "resolved": "https://registry.npmjs.org/minecraft-protocol/-/minecraft-protocol-1.62.0.tgz",
+      "integrity": "sha512-+Rm7DdwgDiiq5ASXLNixs6TA7tsNn8zJAlhmOh0ccfuMYnlr/5+FliKacf87ZO6MPs5p/mJitIAwONbfqiX2+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@types/node-rsa": "^1.1.4",
+        "@types/readable-stream": "^4.0.0",
+        "aes-js": "^3.1.2",
+        "buffer-equal": "^1.0.0",
+        "debug": "^4.3.2",
+        "endian-toggle": "^0.0.0",
+        "lodash.merge": "^4.3.0",
+        "minecraft-data": "^3.78.0",
+        "minecraft-folder-path": "^1.2.0",
+        "node-fetch": "^2.6.1",
+        "node-rsa": "^0.4.2",
+        "prismarine-auth": "^2.2.0",
+        "prismarine-chat": "^1.10.0",
+        "prismarine-nbt": "^2.5.0",
+        "prismarine-realms": "^1.2.0",
+        "protodef": "^1.17.0",
+        "readable-stream": "^4.1.0",
+        "uuid-1345": "^1.0.1",
+        "yggdrasil": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/minecraft-protocol/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mineflayer": {
+      "version": "4.33.0",
+      "resolved": "https://registry.npmjs.org/mineflayer/-/mineflayer-4.33.0.tgz",
+      "integrity": "sha512-tysUKVhUpEvHKDn8Awex/wz8WYyRGYrl6EujOVLJsGOU775AwKcapBVAS1BrP0UbM2di6MDwb74muGAFytY+TQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^3.98.0",
+        "minecraft-protocol": "^1.61.0",
+        "prismarine-biome": "^1.1.1",
+        "prismarine-block": "^1.22.0",
+        "prismarine-chat": "^1.7.1",
+        "prismarine-chunk": "^1.39.0",
+        "prismarine-entity": "^2.5.0",
+        "prismarine-item": "^1.17.0",
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-physics": "^1.9.0",
+        "prismarine-recipe": "^1.3.0",
+        "prismarine-registry": "^1.10.0",
+        "prismarine-windows": "^2.9.0",
+        "prismarine-world": "^3.6.0",
+        "protodef": "^1.18.0",
+        "typed-emitter": "^1.0.0",
+        "vec3": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
+    "node_modules/mineflayer-pathfinder": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/mineflayer-pathfinder/-/mineflayer-pathfinder-2.4.5.tgz",
+      "integrity": "sha512-Jh3JnUgRLwhMh2Dugo4SPza68C41y+NPP5sdsgxRu35ydndo70i1JJGxauVWbXrpNwIxYNztUw78aFyb7icw8g==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^3.5.1",
+        "prismarine-block": "^1.16.3",
+        "prismarine-entity": "^2.1.1",
+        "prismarine-item": "^1.11.5",
+        "prismarine-nbt": "^2.2.1",
+        "prismarine-physics": "^1.5.2",
+        "vec3": "^0.1.7"
+      }
+    },
+    "node_modules/mineflayer-pvp": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/mineflayer-pvp/-/mineflayer-pvp-1.3.2.tgz",
+      "integrity": "sha512-CI2T5w4ceiQdQRCFdrCs3OYmvO9G0cOx2qovUt6f27gknpVI90Ihe1qYhf+zBZJCg9uP1oJ1Pemlzw46Mm3wcA==",
+      "license": "MIT",
+      "dependencies": {
+        "mineflayer": "^4.0.0",
+        "mineflayer-pathfinder": "^2.0.0",
+        "mineflayer-utils": "^0.1.4"
+      }
+    },
+    "node_modules/mineflayer-tester": {
+      "resolved": "apps/mineflayer-tester",
+      "link": true
+    },
+    "node_modules/mineflayer-utils": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/mineflayer-utils/-/mineflayer-utils-0.1.4.tgz",
+      "integrity": "sha512-8+0dbGAjA6FO62/W80v5k44AuSAcwJUMdpMAAGhjI9AdCDz+UuyTnNkPBncF4EcLY7yUUdtA7m/OXQZKFdWOlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^14.0.27",
+        "mineflayer": "^2.27.0",
+        "prismarine-entity": "^1.0.0",
+        "require-self": "^0.2.3",
+        "typescript": "^3.9.7"
+      }
+    },
+    "node_modules/mineflayer-utils/node_modules/@types/node": {
+      "version": "14.18.63",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
+      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
+      "license": "MIT"
+    },
+    "node_modules/mineflayer-utils/node_modules/minecraft-data": {
+      "version": "2.221.0",
+      "resolved": "https://registry.npmjs.org/minecraft-data/-/minecraft-data-2.221.0.tgz",
+      "integrity": "sha512-0AhqzbIKb6WqPSF6qBevaPryeWOz545hLxt6q+gfJF8YIQX/YfkyX/nXWhl+pSIS2rTBcQ0RJkRCtTeRzQwHDA==",
+      "license": "MIT"
+    },
+    "node_modules/mineflayer-utils/node_modules/mineflayer": {
+      "version": "2.41.0",
+      "resolved": "https://registry.npmjs.org/mineflayer/-/mineflayer-2.41.0.tgz",
+      "integrity": "sha512-IFFy4NgF24FU2PkAwazJphl2F+3gpbpN578ex0sq1XfcBBRge3kCz1UC2KDMjKI+V/8vffOL+OEnug9jt3f7Vw==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^2.70.0",
+        "minecraft-protocol": "^1.17.0",
+        "prismarine-biome": "^1.1.0",
+        "prismarine-block": "^1.6.0",
+        "prismarine-chat": "^1.0.0",
+        "prismarine-chunk": "^1.20.3",
+        "prismarine-entity": "^1.0.0",
+        "prismarine-item": "^1.5.0",
+        "prismarine-physics": "^1.0.4",
+        "prismarine-recipe": "^1.1.0",
+        "prismarine-windows": "^1.5.0",
+        "prismarine-world": "^3.2.0",
+        "protodef": "^1.8.0",
+        "typed-emitter": "^1.2.0",
+        "vec3": "^0.1.6"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/mineflayer-utils/node_modules/prismarine-entity": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/prismarine-entity/-/prismarine-entity-1.2.0.tgz",
+      "integrity": "sha512-4dQ9LYl6HDJQrwZHjSKU4D5VNyHRnfrjcw7eVLlbRPkuR50utW5mmfPi4ys9U7tHNmGWHC/cwjH9xzT75LUovQ==",
+      "license": "MIT",
+      "dependencies": {
+        "vec3": "^0.1.4"
+      }
+    },
+    "node_modules/mineflayer-utils/node_modules/prismarine-windows": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/prismarine-windows/-/prismarine-windows-1.6.0.tgz",
+      "integrity": "sha512-026LG1yR76Xb62kM+W83IWT7Wy2yKplllbXNFBF2m0Lr4k4YpYKnpLb8tRft8MLOLRbYAt/KnxE/YKvRZul7kw==",
+      "license": "MIT",
+      "dependencies": {
+        "prismarine-item": "^1.4.0"
+      }
+    },
+    "node_modules/mineflayer-utils/node_modules/typescript": {
+      "version": "3.9.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+      "integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/minimatch": {
@@ -10292,6 +11356,21 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/mojangson": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/mojangson/-/mojangson-2.0.4.tgz",
+      "integrity": "sha512-HYmhgDjr1gzF7trGgvcC/huIg2L8FsVbi/KacRe6r1AswbboGVZDS47SOZlomPuMWvZLas8m9vuHHucdZMwTmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "nearley": "^2.19.5"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
+      "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/motion-dom": {
       "version": "11.18.1",
@@ -10381,6 +11460,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
+    },
+    "node_modules/nearley/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/next-themes": {
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
@@ -10438,6 +11554,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-rsa": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-rsa/-/node-rsa-0.4.2.tgz",
+      "integrity": "sha512-Bvso6Zi9LY4otIZefYrscsUpo2mUpiAVIEmSZV2q41sP8tHZoert3Yu6zv4f/RXJqMNZQKCtnhDugIuCma23YA==",
+      "license": "MIT",
+      "dependencies": {
+        "asn1": "0.2.3"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -10489,7 +11614,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10596,6 +11720,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/once": {
@@ -10728,6 +11874,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -10784,6 +11939,12 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
     },
     "node_modules/path-type": {
       "version": "4.0.0",
@@ -10992,6 +12153,218 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/prismarine-auth": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/prismarine-auth/-/prismarine-auth-2.7.0.tgz",
+      "integrity": "sha512-L8wTF6sdtnN6hViPNy+Nx39a8iQBwR5iO92AWCiym5cSXp/92pmnuwnTdcmNDWyqq6zY4hbibVGYhgLA1Ox8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure/msal-node": "^2.0.2",
+        "@xboxreplay/xboxlive-auth": "^3.3.3",
+        "debug": "^4.3.3",
+        "smart-buffer": "^4.1.0",
+        "uuid-1345": "^1.0.2"
+      }
+    },
+    "node_modules/prismarine-biome": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/prismarine-biome/-/prismarine-biome-1.3.0.tgz",
+      "integrity": "sha512-GY6nZxq93mTErT7jD7jt8YS1aPrOakbJHh39seYsJFXvueIOdHAmW16kYQVrTVMW5MlWLQVxV/EquRwOgr4MnQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "minecraft-data": "^3.0.0",
+        "prismarine-registry": "^1.1.0"
+      }
+    },
+    "node_modules/prismarine-block": {
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/prismarine-block/-/prismarine-block-1.22.0.tgz",
+      "integrity": "sha512-SKVTm+CHR5mY/d+delryqzB2hMH8HIPse8b0O51Ez2R5zPFtKVCLGk5NG71kCDKbMzhhev2iF0O4UC/fWDXhRw==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^3.38.0",
+        "prismarine-biome": "^1.1.0",
+        "prismarine-chat": "^1.5.0",
+        "prismarine-item": "^1.10.1",
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-registry": "^1.1.0"
+      }
+    },
+    "node_modules/prismarine-chat": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prismarine-chat/-/prismarine-chat-1.12.0.tgz",
+      "integrity": "sha512-+1QBUn4WGXbAGwoGwJy31/FvH6JtTBHh//yU0xwOiVnBO71+6Ij0hYMd9PzTTAwR9bySfl/YLltGPBftUAOYOA==",
+      "license": "MIT",
+      "dependencies": {
+        "mojangson": "^2.0.1",
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-registry": "^1.4.0"
+      }
+    },
+    "node_modules/prismarine-chunk": {
+      "version": "1.39.0",
+      "resolved": "https://registry.npmjs.org/prismarine-chunk/-/prismarine-chunk-1.39.0.tgz",
+      "integrity": "sha512-RJHACPV2T3ABGlj0+q/ZUDBLPcslWTIa12lWyE2jJb/svqpTBx8S/K6VjHxhyJ488L9ZWdEmOAr+CHMZJtwWHw==",
+      "license": "MIT",
+      "dependencies": {
+        "prismarine-biome": "^1.2.0",
+        "prismarine-block": "^1.14.1",
+        "prismarine-nbt": "^2.2.1",
+        "prismarine-registry": "^1.1.0",
+        "smart-buffer": "^4.1.0",
+        "uint4": "^0.1.2",
+        "vec3": "^0.1.3",
+        "xxhash-wasm": "^0.4.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/prismarine-entity": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/prismarine-entity/-/prismarine-entity-2.5.0.tgz",
+      "integrity": "sha512-nRPCawUwf9r3iKqi4I7mZRlir1Ix+DffWYdWq6p/KNnmiXve+xHE5zv8XCdhZlUmOshugHv5ONl9o6ORAkCNIA==",
+      "license": "MIT",
+      "dependencies": {
+        "prismarine-chat": "^1.4.1",
+        "prismarine-item": "^1.11.2",
+        "prismarine-registry": "^1.4.0",
+        "vec3": "^0.1.4"
+      }
+    },
+    "node_modules/prismarine-item": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prismarine-item/-/prismarine-item-1.17.0.tgz",
+      "integrity": "sha512-wN1OjP+f+Uvtjo3KzeCkVSy96CqZ8yG7cvuvlGwcYupQ6ct7LtNkubHp0AHuLMJ0vbbfAC0oZ2bWOgI1DYp8WA==",
+      "license": "MIT",
+      "dependencies": {
+        "prismarine-nbt": "^2.0.0",
+        "prismarine-registry": "^1.4.0"
+      }
+    },
+    "node_modules/prismarine-nbt": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/prismarine-nbt/-/prismarine-nbt-2.7.0.tgz",
+      "integrity": "sha512-Du9OLQAcCj3y29YtewOJbbV4ARaSUEJiTguw0PPQbPBy83f+eCyDRkyBpnXTi/KPyEpgYCzsjGzElevLpFoYGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protodef": "^1.18.0"
+      }
+    },
+    "node_modules/prismarine-physics": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/prismarine-physics/-/prismarine-physics-1.10.0.tgz",
+      "integrity": "sha512-FE2xUSDhrdgjlJFtBPMTQt1FX3uG2YvKceRvoMmhcCni0MrS8365ZlbIcW06SB1sKIpoNQWanS5LuefynzwdXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^3.0.0",
+        "prismarine-nbt": "^2.0.0",
+        "vec3": "^0.1.7"
+      }
+    },
+    "node_modules/prismarine-realms": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prismarine-realms/-/prismarine-realms-1.3.2.tgz",
+      "integrity": "sha512-5apl9Ru8veTj5q2OozRc4GZOuSIcs3yY4UEtALiLKHstBe8bRw8vNlaz4Zla3jsQ8yP/ul1b1IJINTRbocuA6g==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.3",
+        "node-fetch": "^2.6.1"
+      }
+    },
+    "node_modules/prismarine-realms/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/prismarine-recipe": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/prismarine-recipe/-/prismarine-recipe-1.3.1.tgz",
+      "integrity": "sha512-xfa9E9ACoaDi+YzNQ+nk8kWSIqt5vSZOOCHIT+dTXscf/dng2HaJ/59uwe1D/jvOkAd2OvM6RRJM6fFe0q/LDA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "prismarine-registry": "^1.4.0"
+      }
+    },
+    "node_modules/prismarine-registry": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/prismarine-registry/-/prismarine-registry-1.11.0.tgz",
+      "integrity": "sha512-uTvWE+bILxYv4i5MrrlxPQ0KYWINv1DJ3P2570GLC8uCdByDiDLBFfVyk4BrqOZBlDBft9CnaJMeOsC1Ly1iXw==",
+      "license": "MIT",
+      "dependencies": {
+        "minecraft-data": "^3.70.0",
+        "prismarine-block": "^1.17.1",
+        "prismarine-nbt": "^2.0.0"
+      }
+    },
+    "node_modules/prismarine-viewer": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/prismarine-viewer/-/prismarine-viewer-1.33.0.tgz",
+      "integrity": "sha512-Kb+3nJkzV5a6kfR1Mqs269bxXHJA5/ZjA+vdwTwDsyZtyib9NC1ELfyTOo/HK77JB+1bS6pfrZB+wcd0+mXKXA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tweenjs/tween.js": "^23.1.1",
+        "compression": "^1.7.4",
+        "express": "^4.17.1",
+        "minecraft-data": "^3.0.0",
+        "prismarine-block": "^1.7.3",
+        "prismarine-chunk": "^1.22.0",
+        "prismarine-world": "^3.3.1",
+        "socket.io": "^4.0.0",
+        "socket.io-client": "^4.0.0",
+        "three": "0.128.0",
+        "three.meshline": "^1.3.0",
+        "vec3": "^0.1.7"
+      }
+    },
+    "node_modules/prismarine-windows": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/prismarine-windows/-/prismarine-windows-2.9.0.tgz",
+      "integrity": "sha512-fm4kOLjGFPov7TEJRmXHoiPabxIQrG36r2mDjlNxfkcLfMHFb3/1ML6mp4iRQa7wL0GK4DIAyiBqCWoeWDxARg==",
+      "license": "MIT",
+      "dependencies": {
+        "prismarine-item": "^1.12.2",
+        "prismarine-registry": "^1.7.0",
+        "typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/prismarine-windows/node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
+    "node_modules/prismarine-world": {
+      "version": "3.6.3",
+      "resolved": "https://registry.npmjs.org/prismarine-world/-/prismarine-world-3.6.3.tgz",
+      "integrity": "sha512-zqdqPEYCDHzqi6hglJldEO63bOROXpbZeIdxBmoQq7o04Lf81t016LU6stFHo3E+bmp5+xU74eDFdOvzYNABkA==",
+      "license": "MIT",
+      "dependencies": {
+        "vec3": "^0.1.7"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/proc-log": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-6.0.0.tgz",
@@ -11000,6 +12373,15 @@
       "license": "ISC",
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/prop-types": {
@@ -11013,11 +12395,49 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/protodef": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/protodef/-/protodef-1.19.0.tgz",
+      "integrity": "sha512-94f3GR7pk4Qi5YVLaLvWBfTGUIzzO8hyo7vFVICQuu5f5nwKtgGDaeC1uXIu49s5to/49QQhEYeL0aigu1jEGA==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash.reduce": "^4.6.0",
+        "protodef-validator": "^1.3.0",
+        "readable-stream": "^4.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/protodef-validator": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/protodef-validator/-/protodef-validator-1.4.0.tgz",
+      "integrity": "sha512-2y2coBolqCEuk5Kc3QwO7ThR+/7TZiOit4FrpAgl+vFMvq8w76nDhh09z08e2NQOdrgPLsN2yzXsvRvtADgUZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.5.4"
+      },
+      "bin": {
+        "protodef-validator": "cli.js"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -11041,6 +12461,21 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -11060,6 +12495,49 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/react": {
       "version": "18.3.1",
@@ -11289,6 +12767,22 @@
         "node": "^20.17.0 || >=22.9.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+      "license": "MIT",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -11456,6 +12950,15 @@
         "type-fest": "^4.41.0"
       }
     },
+    "node_modules/require-self": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/require-self/-/require-self-0.2.3.tgz",
+      "integrity": "sha512-keGBWkK0PWJGFAd6IznpjM5zZzySbsrvzq0ElXpZ4G8hzymV9I+/OnC916MF5mRxHRWSZKGIyCFJ73BZFz3xaA==",
+      "license": "MIT",
+      "bin": {
+        "require-self": "bin/require-self"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -11493,6 +12996,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/reusify": {
@@ -11551,6 +13063,16 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -11570,6 +13092,26 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/safe-push-apply": {
       "version": "1.0.0",
@@ -11605,6 +13147,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
     },
     "node_modules/satori": {
       "version": "0.12.2",
@@ -11653,6 +13201,158 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.1.tgz",
+      "integrity": "sha512-p4rRk4f23ynFEfcD9LA0xRYngj+IyGiEYyqqOak8kaN0TvNmuxC2dcVeBn62GpCeR2CpWqyHCNScTP91QbAVFg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/send/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/send/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-static/node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/serve-static/node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve-static/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/set-cookie-parser": {
@@ -11709,6 +13409,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
     },
     "node_modules/sharp": {
       "version": "0.34.5",
@@ -11780,7 +13486,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11800,7 +13505,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -11817,7 +13521,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11836,7 +13539,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -11862,6 +13564,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/socket.io-client": {
@@ -11926,6 +13704,23 @@
         }
       }
     },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/sonner": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
@@ -11961,6 +13756,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -11973,6 +13777,15 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -12521,6 +14334,20 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/three": {
+      "version": "0.128.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.128.0.tgz",
+      "integrity": "sha512-i0ap/E+OaSfzw7bD1TtYnPo3VEplkl70WX5fZqZnfZsE3k3aSFudqrrC9ldFZfYFkn1zwDmBcdGfiIm/hnbyZA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/three.meshline": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/three.meshline/-/three.meshline-1.4.0.tgz",
+      "integrity": "sha512-A8IsiMrWP8zmHisGDAJ76ZD7t/dOF/oCe/FUKNE6Bu01ZYEx8N6IlU/1Plb2aOZtAuWM2A8s8qS3hvY0OFuvOw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/tiny-inflate": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
@@ -12591,6 +14418,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/tr46": {
@@ -12815,6 +14651,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/typed-array-buffer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
@@ -12893,6 +14742,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typed-emitter": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-1.4.0.tgz",
+      "integrity": "sha512-weBmoo3HhpKGgLBOYwe8EB31CzDFuaK7CCL+axXhUYhn4jo6DSkHnbefboCF5i4DQ2aMFe0C/FdTWcPdObgHyg==",
+      "license": "MIT"
+    },
     "node_modules/typed.js": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/typed.js/-/typed.js-2.1.0.tgz",
@@ -12912,6 +14767,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/uint4": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/uint4/-/uint4-0.1.2.tgz",
+      "integrity": "sha512-lhEx78gdTwFWG+mt6cWAZD/R6qrIj0TTBeH5xwyuDJyswLNlGe+KVlUPQ6+mx5Ld332pS0AMUTo9hIly7YsWxQ==",
+      "license": "MIT"
     },
     "node_modules/unbox-primitive": {
       "version": "1.1.0",
@@ -12998,6 +14859,15 @@
         "tiny-inflate": "^1.0.0"
       }
     },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -13068,7 +14938,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -13146,6 +15015,15 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/uuid": {
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
@@ -13157,6 +15035,24 @@
       "license": "MIT",
       "bin": {
         "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/uuid-1345": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/uuid-1345/-/uuid-1345-1.0.2.tgz",
+      "integrity": "sha512-bA5zYZui+3nwAc0s3VdGQGBfbVsJLVX7Np7ch2aqcEWFi5lsAEcmO3+lx3djM1npgpZI8KY2FITZ2uYTnYUYyw==",
+      "license": "MIT",
+      "dependencies": {
+        "macaddress": "^0.5.1"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/vaul": {
@@ -13171,6 +15067,12 @@
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc"
       }
+    },
+    "node_modules/vec3": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/vec3/-/vec3-0.1.10.tgz",
+      "integrity": "sha512-Sr1U3mYtMqCOonGd3LAN9iqy0qF6C+Gjil92awyK/i2OwiUo9bm7PnLgFpafymun50mOjnDcg4ToTgRssrlTcw==",
+      "license": "BSD"
     },
     "node_modules/victory-vendor": {
       "version": "36.9.2",
@@ -13402,6 +15304,12 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/xxhash-wasm": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-0.4.2.tgz",
+      "integrity": "sha512-/eyHVRJQCirEkSZ1agRSCwriMhwlyUcFkXD5TPVSLP+IPzjsqMVzZwdoczLp1SoQU0R3dxz1RpIK+4YNQbCVOA==",
+      "license": "MIT"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -13416,6 +15324,45 @@
       "license": "ISC",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/yggdrasil": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/yggdrasil/-/yggdrasil-1.7.0.tgz",
+      "integrity": "sha512-QBIo5fiNd7688G3FqXXYGr36uyrYzczlNuzpWFy2zL3+R+3KT2lF+wFxm51synfA3l3z6IBiGOc1/EVXWCYY1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.6.1",
+        "uuid": "^8.2.0"
+      }
+    },
+    "node_modules/yggdrasil/node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yggdrasil/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/yocto-queue": {


### PR DESCRIPTION
- Introduced a new application for testing Mineflayer bots on the BlockWarriors Minecraft server.
- Added essential files including package.json, README.md, and .gitignore for the new app.
- Implemented bot management features with a server using Express and Socket.io.
- Created a user interface for bot control, including movement, chat, and attack functionalities.
- Integrated pathfinding and PvP capabilities for bots using mineflayer plugins.
- Established a minimap for visualizing bot positions and actions.
- Included comprehensive logging for bot activities and errors.


I wouldn't merge this in just yet.. it is a little buggy