### PR TITLE
Ns iamin/game setup

### DIFF
--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/Plugin.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/Plugin.java
@@ -13,6 +13,8 @@ import ai.blockwarriors.commands.LoginCommand;
 import ai.blockwarriors.commands.debug.CreateMatchCommand;
 import ai.blockwarriors.commands.debug.ListLoggedInCommand;
 import ai.blockwarriors.events.PlayerEventListener;
+import ai.blockwarriors.beacon.arena.ArenaManager;
+import ai.blockwarriors.beacon.game.GameRegistry;
 import ai.blockwarriors.beacon.service.MatchPollingService;
 import ai.blockwarriors.beacon.service.MatchTelemetryService;
 import ai.blockwarriors.beacon.service.MatchManager;
@@ -28,6 +30,7 @@ public class Plugin extends JavaPlugin {
     private MatchPollingService matchPollingService;
     private MatchTelemetryService matchTelemetryService;
     private MatchManager matchManager;
+    private ArenaManager arenaManager;
     private String convexSiteUrl;
     private String convexHttpSecret;
 
@@ -41,6 +44,10 @@ public class Plugin extends JavaPlugin {
 
     public MatchManager getMatchManager() {
         return matchManager;
+    }
+
+    public ArenaManager getArenaManager() {
+        return arenaManager;
     }
 
     public String getConvexSiteUrl() {
@@ -70,6 +77,11 @@ public class Plugin extends JavaPlugin {
             LOGGER.warning("CONVEX_HTTP_SECRET is not configured! Please set it in config.yml or as an environment variable.");
         }
 
+        // Initialize arena manager and load arena configurations
+        arenaManager = new ArenaManager(this);
+        arenaManager.loadArenas();
+        LOGGER.info("ArenaManager initialized with " + arenaManager.getArenaCount() + " arenas");
+
         // Initialize match manager
         matchManager = new MatchManager(this, convexSiteUrl, convexHttpSecret);
 
@@ -78,6 +90,11 @@ public class Plugin extends JavaPlugin {
 
         // Link telemetry service to match manager
         matchManager.setTelemetryService(matchTelemetryService);
+
+        // Initialize GameRegistry (game types will be registered by individual game plugins/modules)
+        GameRegistry.getInstance();
+        LOGGER.info("GameRegistry initialized. Registered game types: " + 
+                   GameRegistry.getInstance().getRegisteredTypes());
 
         // Initialize login command with Convex URL and secret
         loginCommand = new LoginCommand(loggedInPlayers, convexSiteUrl, convexHttpSecret);
@@ -98,6 +115,7 @@ public class Plugin extends JavaPlugin {
         // Initialize and start match polling service
         matchPollingService = new MatchPollingService(this, convexSiteUrl, convexHttpSecret);
         matchPollingService.setMatchManager(matchManager);
+        matchPollingService.setArenaManager(arenaManager);
         matchPollingService.start();
         LOGGER.info("MatchPollingService started with Convex URL: " + convexSiteUrl);
 
@@ -129,6 +147,9 @@ public class Plugin extends JavaPlugin {
         if (matchTelemetryService != null) {
             matchTelemetryService.stop();
         }
+
+        // Clear GameRegistry
+        GameRegistry.getInstance().clearAll();
 
         LOGGER.info("beacon plugin disabled");
     }

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/Plugin.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/Plugin.java
@@ -96,8 +96,9 @@ public class Plugin extends JavaPlugin {
         // Initialize match telemetry service
         matchTelemetryService = new MatchTelemetryService(this, convexSiteUrl, convexHttpSecret);
 
-        // Link telemetry service to match manager
+        // Link telemetry service and match manager bidirectionally
         matchManager.setTelemetryService(matchTelemetryService);
+        matchTelemetryService.setMatchManager(matchManager);
 
         // Initialize GameRegistry and register game types
         GameRegistry registry = GameRegistry.getInstance();

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/Plugin.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/Plugin.java
@@ -11,10 +11,18 @@ import org.bukkit.plugin.java.JavaPlugin;
 
 import ai.blockwarriors.commands.LoginCommand;
 import ai.blockwarriors.commands.debug.CreateMatchCommand;
+import ai.blockwarriors.commands.debug.EndGameCommand;
 import ai.blockwarriors.commands.debug.ListLoggedInCommand;
+import ai.blockwarriors.commands.debug.SetArenaCommand;
+import ai.blockwarriors.commands.debug.SimulateDisconnectCommand;
+import ai.blockwarriors.commands.debug.SimulateReconnectCommand;
+import ai.blockwarriors.commands.debug.TestGameCommand;
+import ai.blockwarriors.commands.debug.TriggerObjectiveCommand;
 import ai.blockwarriors.events.PlayerEventListener;
 import ai.blockwarriors.beacon.arena.ArenaManager;
+import ai.blockwarriors.beacon.constants.GameConfig;
 import ai.blockwarriors.beacon.game.GameRegistry;
+import ai.blockwarriors.beacon.game.impl.PvPGame;
 import ai.blockwarriors.beacon.service.MatchPollingService;
 import ai.blockwarriors.beacon.service.MatchTelemetryService;
 import ai.blockwarriors.beacon.service.MatchManager;
@@ -91,10 +99,24 @@ public class Plugin extends JavaPlugin {
         // Link telemetry service to match manager
         matchManager.setTelemetryService(matchTelemetryService);
 
-        // Initialize GameRegistry (game types will be registered by individual game plugins/modules)
-        GameRegistry.getInstance();
+        // Initialize GameRegistry and register game types
+        GameRegistry registry = GameRegistry.getInstance();
+        
+        // Register PvP game type with metadata
+        registry.registerGame(
+            GameConfig.GAME_TYPE_PVP,
+            PvPGame::new,
+            GameRegistry.GameMetadata.builder()
+                .displayName("Normal PvP")
+                .description("Classic 1v1 player versus player combat")
+                .playersPerTeam(1)
+                .teamCount(2)
+                .defaultArena("pvp")
+                .build()
+        );
+        
         LOGGER.info("GameRegistry initialized. Registered game types: " + 
-                   GameRegistry.getInstance().getRegisteredTypes());
+                   registry.getRegisteredTypes());
 
         // Initialize login command with Convex URL and secret
         loginCommand = new LoginCommand(loggedInPlayers, convexSiteUrl, convexHttpSecret);
@@ -104,6 +126,43 @@ public class Plugin extends JavaPlugin {
         registerCommand("creatematch", new CreateMatchCommand());
         registerCommand("listloggedin", new ListLoggedInCommand(loggedInPlayers));
         registerCommand("bypass", new ai.blockwarriors.commands.BypassCommand(bypassedPlayers));
+        
+        // Register debug commands
+        TestGameCommand testGameCommand = new TestGameCommand(this);
+        registerCommand("testgame", testGameCommand);
+        if (getCommand("testgame") != null) {
+            getCommand("testgame").setTabCompleter(testGameCommand);
+        }
+        
+        SetArenaCommand setArenaCommand = new SetArenaCommand(this);
+        registerCommand("setarena", setArenaCommand);
+        if (getCommand("setarena") != null) {
+            getCommand("setarena").setTabCompleter(setArenaCommand);
+        }
+        
+        EndGameCommand endGameCommand = new EndGameCommand(this);
+        registerCommand("endgame", endGameCommand);
+        if (getCommand("endgame") != null) {
+            getCommand("endgame").setTabCompleter(endGameCommand);
+        }
+        
+        TriggerObjectiveCommand triggerObjectiveCommand = new TriggerObjectiveCommand(this);
+        registerCommand("triggerobjective", triggerObjectiveCommand);
+        if (getCommand("triggerobjective") != null) {
+            getCommand("triggerobjective").setTabCompleter(triggerObjectiveCommand);
+        }
+        
+        SimulateDisconnectCommand simulateDisconnectCommand = new SimulateDisconnectCommand(this);
+        registerCommand("simulatedisconnect", simulateDisconnectCommand);
+        if (getCommand("simulatedisconnect") != null) {
+            getCommand("simulatedisconnect").setTabCompleter(simulateDisconnectCommand);
+        }
+        
+        SimulateReconnectCommand simulateReconnectCommand = new SimulateReconnectCommand(this);
+        registerCommand("simulatereconnect", simulateReconnectCommand);
+        if (getCommand("simulatereconnect") != null) {
+            getCommand("simulatereconnect").setTabCompleter(simulateReconnectCommand);
+        }
 
         // Register event listeners
         getServer().getPluginManager()

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/arena/ArenaBoundary.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/arena/ArenaBoundary.java
@@ -1,0 +1,148 @@
+package ai.blockwarriors.beacon.arena;
+
+import org.bukkit.Location;
+
+/**
+ * Represents the boundaries of an arena as an axis-aligned bounding box.
+ * Used for detecting when players leave the arena or for void detection.
+ */
+public class ArenaBoundary {
+    
+    private final double minX;
+    private final double minY;
+    private final double minZ;
+    private final double maxX;
+    private final double maxY;
+    private final double maxZ;
+    
+    /**
+     * Create arena boundaries.
+     * 
+     * @param minX Minimum X coordinate
+     * @param minY Minimum Y coordinate
+     * @param minZ Minimum Z coordinate
+     * @param maxX Maximum X coordinate
+     * @param maxY Maximum Y coordinate
+     * @param maxZ Maximum Z coordinate
+     */
+    public ArenaBoundary(double minX, double minY, double minZ,
+                         double maxX, double maxY, double maxZ) {
+        // Ensure min <= max
+        this.minX = Math.min(minX, maxX);
+        this.minY = Math.min(minY, maxY);
+        this.minZ = Math.min(minZ, maxZ);
+        this.maxX = Math.max(minX, maxX);
+        this.maxY = Math.max(minY, maxY);
+        this.maxZ = Math.max(minZ, maxZ);
+    }
+    
+    /**
+     * Create arena boundaries from two corner coordinates.
+     */
+    public static ArenaBoundary fromCorners(double x1, double y1, double z1,
+                                            double x2, double y2, double z2) {
+        return new ArenaBoundary(x1, y1, z1, x2, y2, z2);
+    }
+    
+    public double getMinX() {
+        return minX;
+    }
+    
+    public double getMinY() {
+        return minY;
+    }
+    
+    public double getMinZ() {
+        return minZ;
+    }
+    
+    public double getMaxX() {
+        return maxX;
+    }
+    
+    public double getMaxY() {
+        return maxY;
+    }
+    
+    public double getMaxZ() {
+        return maxZ;
+    }
+    
+    /**
+     * Check if a location is within the boundaries.
+     * 
+     * @param location The location to check
+     * @return true if location is within boundaries
+     */
+    public boolean contains(Location location) {
+        return contains(location.getX(), location.getY(), location.getZ());
+    }
+    
+    /**
+     * Check if coordinates are within the boundaries.
+     */
+    public boolean contains(double x, double y, double z) {
+        return x >= minX && x <= maxX &&
+               y >= minY && y <= maxY &&
+               z >= minZ && z <= maxZ;
+    }
+    
+    /**
+     * Check if a location is below the minimum Y (void death).
+     */
+    public boolean isBelowFloor(Location location) {
+        return location.getY() < minY;
+    }
+    
+    /**
+     * Check if a location is within XZ bounds but at any Y level.
+     * Useful for checking horizontal boundaries.
+     */
+    public boolean containsXZ(double x, double z) {
+        return x >= minX && x <= maxX && z >= minZ && z <= maxZ;
+    }
+    
+    /**
+     * Get the volume of the boundary box.
+     */
+    public double getVolume() {
+        return (maxX - minX) * (maxY - minY) * (maxZ - minZ);
+    }
+    
+    /**
+     * Get the center point of the boundary.
+     */
+    public double[] getCenter() {
+        return new double[] {
+            (minX + maxX) / 2,
+            (minY + maxY) / 2,
+            (minZ + maxZ) / 2
+        };
+    }
+    
+    /**
+     * Create a boundary offset from an arena origin.
+     */
+    public ArenaBoundary withOffset(double originX, double originY, double originZ) {
+        return new ArenaBoundary(
+            minX + originX, minY + originY, minZ + originZ,
+            maxX + originX, maxY + originY, maxZ + originZ
+        );
+    }
+    
+    /**
+     * Expand the boundary by a given amount in all directions.
+     */
+    public ArenaBoundary expand(double amount) {
+        return new ArenaBoundary(
+            minX - amount, minY - amount, minZ - amount,
+            maxX + amount, maxY + amount, maxZ + amount
+        );
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("ArenaBoundary{min=(%.1f, %.1f, %.1f), max=(%.1f, %.1f, %.1f)}",
+                minX, minY, minZ, maxX, maxY, maxZ);
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/arena/ArenaConfig.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/arena/ArenaConfig.java
@@ -1,0 +1,288 @@
+package ai.blockwarriors.beacon.arena;
+
+import java.util.*;
+
+/**
+ * Configuration for an arena, loaded from YAML files.
+ * 
+ * Contains all the information needed to set up a game arena:
+ * - Name and game type
+ * - Schematic file path
+ * - Team spawn points
+ * - Arena boundaries
+ * - Game-specific objectives and markers
+ */
+public class ArenaConfig {
+    
+    /** Display name of the arena */
+    private final String name;
+    
+    /** Game type this arena is for (e.g., "pvp", "sky_tiles") */
+    private final String gameType;
+    
+    /** Path to the WorldEdit schematic file (relative to schematics folder) */
+    private final String schematicPath;
+    
+    /** Spawn points by team name (e.g., "blue_team", "red_team") */
+    private final Map<String, List<SpawnPoint>> spawns;
+    
+    /** Arena boundaries for out-of-bounds detection */
+    private final ArenaBoundary boundaries;
+    
+    /** Game-specific objectives (e.g., flag locations, bed positions) */
+    private final Map<String, Object> objectives;
+    
+    /** Resource spawn locations (for games with item spawning) */
+    private final List<ResourceSpawn> resources;
+    
+    /** Special block locations (respawn anchors, objective blocks, etc.) */
+    private final Map<String, List<SpawnPoint>> specialBlocks;
+    
+    /**
+     * Create an arena configuration with all parameters.
+     */
+    public ArenaConfig(String name, String gameType, String schematicPath,
+                       Map<String, List<SpawnPoint>> spawns, ArenaBoundary boundaries,
+                       Map<String, Object> objectives, List<ResourceSpawn> resources,
+                       Map<String, List<SpawnPoint>> specialBlocks) {
+        this.name = name;
+        this.gameType = gameType;
+        this.schematicPath = schematicPath;
+        this.spawns = spawns != null ? new HashMap<>(spawns) : new HashMap<>();
+        this.boundaries = boundaries;
+        this.objectives = objectives != null ? new HashMap<>(objectives) : new HashMap<>();
+        this.resources = resources != null ? new ArrayList<>(resources) : new ArrayList<>();
+        this.specialBlocks = specialBlocks != null ? new HashMap<>(specialBlocks) : new HashMap<>();
+    }
+    
+    /**
+     * Builder for creating ArenaConfig instances.
+     */
+    public static class Builder {
+        private String name;
+        private String gameType;
+        private String schematicPath;
+        private final Map<String, List<SpawnPoint>> spawns = new HashMap<>();
+        private ArenaBoundary boundaries;
+        private final Map<String, Object> objectives = new HashMap<>();
+        private final List<ResourceSpawn> resources = new ArrayList<>();
+        private final Map<String, List<SpawnPoint>> specialBlocks = new HashMap<>();
+        
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+        
+        public Builder gameType(String gameType) {
+            this.gameType = gameType;
+            return this;
+        }
+        
+        public Builder schematicPath(String path) {
+            this.schematicPath = path;
+            return this;
+        }
+        
+        public Builder addSpawns(String team, List<SpawnPoint> points) {
+            this.spawns.put(team, new ArrayList<>(points));
+            return this;
+        }
+        
+        public Builder addSpawn(String team, SpawnPoint point) {
+            this.spawns.computeIfAbsent(team, k -> new ArrayList<>()).add(point);
+            return this;
+        }
+        
+        public Builder boundaries(ArenaBoundary boundaries) {
+            this.boundaries = boundaries;
+            return this;
+        }
+        
+        public Builder addObjective(String key, Object value) {
+            this.objectives.put(key, value);
+            return this;
+        }
+        
+        public Builder addResource(ResourceSpawn resource) {
+            this.resources.add(resource);
+            return this;
+        }
+        
+        public Builder addSpecialBlock(String type, SpawnPoint location) {
+            this.specialBlocks.computeIfAbsent(type, k -> new ArrayList<>()).add(location);
+            return this;
+        }
+        
+        public ArenaConfig build() {
+            if (name == null || gameType == null) {
+                throw new IllegalStateException("Arena name and gameType are required");
+            }
+            return new ArenaConfig(name, gameType, schematicPath, spawns, boundaries,
+                    objectives, resources, specialBlocks);
+        }
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    // ==================== Getters ====================
+    
+    public String getName() {
+        return name;
+    }
+    
+    public String getGameType() {
+        return gameType;
+    }
+    
+    public String getSchematicPath() {
+        return schematicPath;
+    }
+    
+    public boolean hasSchematic() {
+        return schematicPath != null && !schematicPath.isEmpty();
+    }
+    
+    /**
+     * Get spawn points for a team.
+     * 
+     * @param team Team name (e.g., "blue_team", "red_team")
+     * @return List of spawn points, or empty list if team not found
+     */
+    public List<SpawnPoint> getSpawns(String team) {
+        return Collections.unmodifiableList(spawns.getOrDefault(team, Collections.emptyList()));
+    }
+    
+    /**
+     * Get all team names that have spawn points defined.
+     */
+    public Set<String> getTeamNames() {
+        return Collections.unmodifiableSet(spawns.keySet());
+    }
+    
+    /**
+     * Get the first spawn point for a team.
+     * Useful for 1v1 games where each team has one spawn.
+     */
+    public SpawnPoint getFirstSpawn(String team) {
+        List<SpawnPoint> teamSpawns = spawns.get(team);
+        return (teamSpawns != null && !teamSpawns.isEmpty()) ? teamSpawns.get(0) : null;
+    }
+    
+    public ArenaBoundary getBoundaries() {
+        return boundaries;
+    }
+    
+    public boolean hasBoundaries() {
+        return boundaries != null;
+    }
+    
+    /**
+     * Get a game-specific objective value.
+     * 
+     * @param key Objective key
+     * @return Objective value, or null if not found
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T getObjective(String key) {
+        return (T) objectives.get(key);
+    }
+    
+    /**
+     * Get all objectives.
+     */
+    public Map<String, Object> getObjectives() {
+        return Collections.unmodifiableMap(objectives);
+    }
+    
+    /**
+     * Get resource spawns.
+     */
+    public List<ResourceSpawn> getResources() {
+        return Collections.unmodifiableList(resources);
+    }
+    
+    /**
+     * Get special block locations by type.
+     */
+    public List<SpawnPoint> getSpecialBlocks(String type) {
+        return Collections.unmodifiableList(
+                specialBlocks.getOrDefault(type, Collections.emptyList()));
+    }
+    
+    /**
+     * Create a copy of this config with spawn points offset from an origin.
+     * Useful when placing arenas at different locations in a world.
+     */
+    public ArenaConfig withOffset(double originX, double originY, double originZ) {
+        Map<String, List<SpawnPoint>> offsetSpawns = new HashMap<>();
+        for (Map.Entry<String, List<SpawnPoint>> entry : spawns.entrySet()) {
+            List<SpawnPoint> offsetPoints = new ArrayList<>();
+            for (SpawnPoint point : entry.getValue()) {
+                offsetPoints.add(point.withOffset(originX, originY, originZ));
+            }
+            offsetSpawns.put(entry.getKey(), offsetPoints);
+        }
+        
+        ArenaBoundary offsetBoundaries = boundaries != null
+                ? boundaries.withOffset(originX, originY, originZ)
+                : null;
+        
+        Map<String, List<SpawnPoint>> offsetSpecialBlocks = new HashMap<>();
+        for (Map.Entry<String, List<SpawnPoint>> entry : specialBlocks.entrySet()) {
+            List<SpawnPoint> offsetPoints = new ArrayList<>();
+            for (SpawnPoint point : entry.getValue()) {
+                offsetPoints.add(point.withOffset(originX, originY, originZ));
+            }
+            offsetSpecialBlocks.put(entry.getKey(), offsetPoints);
+        }
+        
+        // Resources also need to be offset
+        List<ResourceSpawn> offsetResources = new ArrayList<>();
+        for (ResourceSpawn resource : resources) {
+            offsetResources.add(resource.withOffset(originX, originY, originZ));
+        }
+        
+        return new ArenaConfig(name, gameType, schematicPath, offsetSpawns, offsetBoundaries,
+                objectives, offsetResources, offsetSpecialBlocks);
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("ArenaConfig{name='%s', gameType='%s', teams=%s, hasSchematic=%s}",
+                name, gameType, spawns.keySet(), hasSchematic());
+    }
+    
+    /**
+     * Configuration for a resource spawn point.
+     */
+    public static class ResourceSpawn {
+        private final String materialType;
+        private final SpawnPoint location;
+        private final int intervalSeconds;
+        
+        public ResourceSpawn(String materialType, SpawnPoint location, int intervalSeconds) {
+            this.materialType = materialType;
+            this.location = location;
+            this.intervalSeconds = intervalSeconds;
+        }
+        
+        public String getMaterialType() {
+            return materialType;
+        }
+        
+        public SpawnPoint getLocation() {
+            return location;
+        }
+        
+        public int getIntervalSeconds() {
+            return intervalSeconds;
+        }
+        
+        public ResourceSpawn withOffset(double originX, double originY, double originZ) {
+            return new ResourceSpawn(materialType,
+                    location.withOffset(originX, originY, originZ), intervalSeconds);
+        }
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/arena/ArenaManager.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/arena/ArenaManager.java
@@ -1,0 +1,465 @@
+package ai.blockwarriors.beacon.arena;
+
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * Manages arena configurations and schematic loading.
+ * 
+ * Arenas are defined in YAML files in the arenas/ resource folder.
+ * Each arena config specifies:
+ * - Spawn points for each team
+ * - Arena boundaries
+ * - Game-specific objectives
+ * - Optional schematic file path
+ * 
+ * Usage:
+ * <pre>
+ * ArenaManager arenaManager = new ArenaManager(plugin);
+ * arenaManager.loadArenas();
+ * 
+ * ArenaConfig config = arenaManager.getArena("pvp");
+ * List<SpawnPoint> blueSpawns = config.getSpawns("blue_team");
+ * </pre>
+ */
+public class ArenaManager {
+    
+    private static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    /** Directory containing arena YAML configs (in resources) */
+    private static final String ARENAS_FOLDER = "arenas";
+    
+    /** Directory containing schematic files (in plugin data folder) */
+    private static final String SCHEMATICS_FOLDER = "schematics";
+    
+    private final JavaPlugin plugin;
+    
+    /** Loaded arena configurations by name */
+    private final Map<String, ArenaConfig> arenas = new HashMap<>();
+    
+    /** Arena configs by game type (multiple arenas per game type allowed) */
+    private final Map<String, List<ArenaConfig>> arenasByGameType = new HashMap<>();
+    
+    /**
+     * Create an ArenaManager.
+     * 
+     * @param plugin The JavaPlugin instance
+     */
+    public ArenaManager(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    /**
+     * Load all arena configurations from the arenas/ resource folder.
+     * Also copies default configs to the plugin data folder if they don't exist.
+     */
+    public void loadArenas() {
+        arenas.clear();
+        arenasByGameType.clear();
+        
+        // Ensure directories exist
+        File arenasDir = new File(plugin.getDataFolder(), ARENAS_FOLDER);
+        File schematicsDir = new File(plugin.getDataFolder(), SCHEMATICS_FOLDER);
+        
+        if (!arenasDir.exists()) {
+            arenasDir.mkdirs();
+            LOGGER.info("Created arenas directory: " + arenasDir.getPath());
+        }
+        
+        if (!schematicsDir.exists()) {
+            schematicsDir.mkdirs();
+            LOGGER.info("Created schematics directory: " + schematicsDir.getPath());
+        }
+        
+        // Save default arena configs from resources
+        saveDefaultArenas();
+        
+        // Load all YAML files from the arenas directory
+        File[] arenaFiles = arenasDir.listFiles((dir, name) -> name.endsWith(".yml") || name.endsWith(".yaml"));
+        
+        if (arenaFiles == null || arenaFiles.length == 0) {
+            LOGGER.warning("No arena configuration files found in " + arenasDir.getPath());
+            return;
+        }
+        
+        for (File file : arenaFiles) {
+            try {
+                ArenaConfig config = loadArenaFile(file);
+                if (config != null) {
+                    registerArena(config);
+                }
+            } catch (Exception e) {
+                LOGGER.severe("Failed to load arena file " + file.getName() + ": " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
+        
+        LOGGER.info("Loaded " + arenas.size() + " arena configurations");
+    }
+    
+    /**
+     * Save default arena configurations from resources to the plugin data folder.
+     */
+    private void saveDefaultArenas() {
+        // List of default arena configs to save
+        String[] defaultArenas = {"pvp.yml"};
+        
+        for (String arenaName : defaultArenas) {
+            String resourcePath = ARENAS_FOLDER + "/" + arenaName;
+            File targetFile = new File(plugin.getDataFolder(), resourcePath);
+            
+            if (!targetFile.exists()) {
+                try (InputStream in = plugin.getResource(resourcePath)) {
+                    if (in != null) {
+                        plugin.saveResource(resourcePath, false);
+                        LOGGER.info("Saved default arena config: " + arenaName);
+                    }
+                } catch (Exception e) {
+                    LOGGER.warning("Could not save default arena " + arenaName + ": " + e.getMessage());
+                }
+            }
+        }
+    }
+    
+    /**
+     * Load an arena configuration from a YAML file.
+     */
+    private ArenaConfig loadArenaFile(File file) {
+        YamlConfiguration yaml = YamlConfiguration.loadConfiguration(file);
+        
+        String name = yaml.getString("name");
+        String gameType = yaml.getString("game_type");
+        
+        if (name == null || gameType == null) {
+            LOGGER.warning("Arena file " + file.getName() + " missing required 'name' or 'game_type'");
+            return null;
+        }
+        
+        ArenaConfig.Builder builder = ArenaConfig.builder()
+                .name(name)
+                .gameType(gameType)
+                .schematicPath(yaml.getString("schematic"));
+        
+        // Load spawns
+        ConfigurationSection spawnsSection = yaml.getConfigurationSection("spawns");
+        if (spawnsSection != null) {
+            for (String teamName : spawnsSection.getKeys(false)) {
+                List<SpawnPoint> spawnPoints = loadSpawnPoints(spawnsSection, teamName);
+                if (!spawnPoints.isEmpty()) {
+                    builder.addSpawns(teamName, spawnPoints);
+                }
+            }
+        }
+        
+        // Load boundaries
+        ConfigurationSection boundariesSection = yaml.getConfigurationSection("boundaries");
+        if (boundariesSection != null) {
+            ArenaBoundary boundary = loadBoundary(boundariesSection);
+            if (boundary != null) {
+                builder.boundaries(boundary);
+            }
+        }
+        
+        // Load objectives
+        ConfigurationSection objectivesSection = yaml.getConfigurationSection("objectives");
+        if (objectivesSection != null) {
+            for (String key : objectivesSection.getKeys(false)) {
+                Object value = objectivesSection.get(key);
+                builder.addObjective(key, value);
+            }
+        }
+        
+        // Load resources
+        List<Map<?, ?>> resourcesList = yaml.getMapList("resources");
+        for (Map<?, ?> resourceMap : resourcesList) {
+            ArenaConfig.ResourceSpawn resource = loadResource(resourceMap);
+            if (resource != null) {
+                builder.addResource(resource);
+            }
+        }
+        
+        // Load special blocks
+        ConfigurationSection specialBlocksSection = yaml.getConfigurationSection("special_blocks");
+        if (specialBlocksSection != null) {
+            for (String blockType : specialBlocksSection.getKeys(false)) {
+                List<SpawnPoint> locations = loadSpawnPoints(specialBlocksSection, blockType);
+                for (SpawnPoint loc : locations) {
+                    builder.addSpecialBlock(blockType, loc);
+                }
+            }
+        }
+        
+        LOGGER.info("Loaded arena: " + name + " (type: " + gameType + ")");
+        return builder.build();
+    }
+    
+    /**
+     * Load spawn points from a configuration section.
+     */
+    private List<SpawnPoint> loadSpawnPoints(ConfigurationSection parent, String key) {
+        List<SpawnPoint> points = new ArrayList<>();
+        
+        // Can be a list of maps or a single map
+        if (parent.isList(key)) {
+            List<Map<?, ?>> spawnList = parent.getMapList(key);
+            for (Map<?, ?> spawnMap : spawnList) {
+                SpawnPoint point = parseSpawnPoint(spawnMap);
+                if (point != null) {
+                    points.add(point);
+                }
+            }
+        } else if (parent.isConfigurationSection(key)) {
+            // Single spawn point as a section
+            ConfigurationSection spawnSection = parent.getConfigurationSection(key);
+            if (spawnSection != null) {
+                SpawnPoint point = parseSpawnPointFromSection(spawnSection);
+                if (point != null) {
+                    points.add(point);
+                }
+            }
+        }
+        
+        return points;
+    }
+    
+    /**
+     * Parse a spawn point from a map.
+     */
+    private SpawnPoint parseSpawnPoint(Map<?, ?> map) {
+        try {
+            double x = getDouble(map, "x", 0);
+            double y = getDouble(map, "y", 64);
+            double z = getDouble(map, "z", 0);
+            float yaw = (float) getDouble(map, "yaw", 0);
+            float pitch = (float) getDouble(map, "pitch", 0);
+            
+            return new SpawnPoint(x, y, z, yaw, pitch);
+        } catch (Exception e) {
+            LOGGER.warning("Failed to parse spawn point: " + e.getMessage());
+            return null;
+        }
+    }
+    
+    /**
+     * Parse a spawn point from a configuration section.
+     */
+    private SpawnPoint parseSpawnPointFromSection(ConfigurationSection section) {
+        try {
+            double x = section.getDouble("x", 0);
+            double y = section.getDouble("y", 64);
+            double z = section.getDouble("z", 0);
+            float yaw = (float) section.getDouble("yaw", 0);
+            float pitch = (float) section.getDouble("pitch", 0);
+            
+            return new SpawnPoint(x, y, z, yaw, pitch);
+        } catch (Exception e) {
+            LOGGER.warning("Failed to parse spawn point section: " + e.getMessage());
+            return null;
+        }
+    }
+    
+    /**
+     * Load boundary configuration.
+     */
+    private ArenaBoundary loadBoundary(ConfigurationSection section) {
+        try {
+            ConfigurationSection minSection = section.getConfigurationSection("min");
+            ConfigurationSection maxSection = section.getConfigurationSection("max");
+            
+            if (minSection == null || maxSection == null) {
+                return null;
+            }
+            
+            double minX = minSection.getDouble("x");
+            double minY = minSection.getDouble("y");
+            double minZ = minSection.getDouble("z");
+            double maxX = maxSection.getDouble("x");
+            double maxY = maxSection.getDouble("y");
+            double maxZ = maxSection.getDouble("z");
+            
+            return new ArenaBoundary(minX, minY, minZ, maxX, maxY, maxZ);
+        } catch (Exception e) {
+            LOGGER.warning("Failed to parse boundary: " + e.getMessage());
+            return null;
+        }
+    }
+    
+    /**
+     * Load a resource spawn configuration.
+     */
+    private ArenaConfig.ResourceSpawn loadResource(Map<?, ?> map) {
+        try {
+            String type = (String) map.get("type");
+            int interval = getInt(map, "interval_seconds", 10);
+            
+            Map<?, ?> locationMap = (Map<?, ?>) map.get("location");
+            SpawnPoint location = parseSpawnPoint(locationMap);
+            
+            if (type == null || location == null) {
+                return null;
+            }
+            
+            return new ArenaConfig.ResourceSpawn(type, location, interval);
+        } catch (Exception e) {
+            LOGGER.warning("Failed to parse resource spawn: " + e.getMessage());
+            return null;
+        }
+    }
+    
+    /**
+     * Helper to get a double from a map.
+     */
+    private double getDouble(Map<?, ?> map, String key, double defaultValue) {
+        Object value = map.get(key);
+        if (value instanceof Number) {
+            return ((Number) value).doubleValue();
+        }
+        return defaultValue;
+    }
+    
+    /**
+     * Helper to get an int from a map.
+     */
+    private int getInt(Map<?, ?> map, String key, int defaultValue) {
+        Object value = map.get(key);
+        if (value instanceof Number) {
+            return ((Number) value).intValue();
+        }
+        return defaultValue;
+    }
+    
+    /**
+     * Register an arena configuration.
+     */
+    private void registerArena(ArenaConfig config) {
+        String arenaId = config.getName().toLowerCase().replace(" ", "_");
+        arenas.put(arenaId, config);
+        
+        arenasByGameType
+                .computeIfAbsent(config.getGameType(), k -> new ArrayList<>())
+                .add(config);
+    }
+    
+    // ==================== Public API ====================
+    
+    /**
+     * Get an arena configuration by name.
+     * 
+     * @param name Arena name (case-insensitive, spaces replaced with underscores)
+     * @return Arena config, or null if not found
+     */
+    public ArenaConfig getArena(String name) {
+        return arenas.get(name.toLowerCase().replace(" ", "_"));
+    }
+    
+    /**
+     * Get all arenas for a game type.
+     * 
+     * @param gameType Game type to filter by
+     * @return List of arena configs for that game type
+     */
+    public List<ArenaConfig> getArenasForGameType(String gameType) {
+        return Collections.unmodifiableList(
+                arenasByGameType.getOrDefault(gameType, Collections.emptyList()));
+    }
+    
+    /**
+     * Get a random arena for a game type.
+     * 
+     * @param gameType Game type
+     * @return Random arena config, or null if none available
+     */
+    public ArenaConfig getRandomArena(String gameType) {
+        List<ArenaConfig> typeArenas = arenasByGameType.get(gameType);
+        if (typeArenas == null || typeArenas.isEmpty()) {
+            return null;
+        }
+        return typeArenas.get(new Random().nextInt(typeArenas.size()));
+    }
+    
+    /**
+     * Get the default arena for a game type (first registered).
+     */
+    public ArenaConfig getDefaultArena(String gameType) {
+        List<ArenaConfig> typeArenas = arenasByGameType.get(gameType);
+        if (typeArenas == null || typeArenas.isEmpty()) {
+            return null;
+        }
+        return typeArenas.get(0);
+    }
+    
+    /**
+     * Get all loaded arena names.
+     */
+    public Set<String> getArenaNames() {
+        return Collections.unmodifiableSet(arenas.keySet());
+    }
+    
+    /**
+     * Get all game types that have arenas.
+     */
+    public Set<String> getGameTypes() {
+        return Collections.unmodifiableSet(arenasByGameType.keySet());
+    }
+    
+    /**
+     * Get spawn points for a team in an arena.
+     * Convenience method that handles null checks.
+     * 
+     * @param arenaName Arena name
+     * @param team Team name (e.g., "blue_team", "red_team")
+     * @return List of spawn points, or empty list if not found
+     */
+    public List<SpawnPoint> getSpawnPoints(String arenaName, String team) {
+        ArenaConfig config = getArena(arenaName);
+        if (config == null) {
+            return Collections.emptyList();
+        }
+        return config.getSpawns(team);
+    }
+    
+    /**
+     * Get the schematic file for an arena.
+     * 
+     * @param arenaName Arena name
+     * @return File object, or null if arena not found or has no schematic
+     */
+    public File getSchematicFile(String arenaName) {
+        ArenaConfig config = getArena(arenaName);
+        if (config == null || !config.hasSchematic()) {
+            return null;
+        }
+        
+        return new File(plugin.getDataFolder(),
+                SCHEMATICS_FOLDER + "/" + config.getSchematicPath());
+    }
+    
+    /**
+     * Check if an arena has a schematic file that exists.
+     */
+    public boolean hasSchematic(String arenaName) {
+        File schematic = getSchematicFile(arenaName);
+        return schematic != null && schematic.exists();
+    }
+    
+    /**
+     * Reload all arena configurations.
+     */
+    public void reloadArenas() {
+        LOGGER.info("Reloading arena configurations...");
+        loadArenas();
+    }
+    
+    /**
+     * Get total number of loaded arenas.
+     */
+    public int getArenaCount() {
+        return arenas.size();
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/arena/SpawnPoint.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/arena/SpawnPoint.java
@@ -1,0 +1,95 @@
+package ai.blockwarriors.beacon.arena;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+
+/**
+ * Represents a spawn point in an arena.
+ * Spawn points define where players appear when the game starts or after respawning.
+ */
+public class SpawnPoint {
+    
+    private final double x;
+    private final double y;
+    private final double z;
+    private final float yaw;
+    private final float pitch;
+    
+    /**
+     * Create a spawn point with position only (facing default direction).
+     */
+    public SpawnPoint(double x, double y, double z) {
+        this(x, y, z, 0.0f, 0.0f);
+    }
+    
+    /**
+     * Create a spawn point with position and rotation.
+     * 
+     * @param x X coordinate
+     * @param y Y coordinate
+     * @param z Z coordinate
+     * @param yaw Horizontal rotation (-180 to 180, 0 = south)
+     * @param pitch Vertical rotation (-90 to 90, negative = up)
+     */
+    public SpawnPoint(double x, double y, double z, float yaw, float pitch) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.yaw = yaw;
+        this.pitch = pitch;
+    }
+    
+    public double getX() {
+        return x;
+    }
+    
+    public double getY() {
+        return y;
+    }
+    
+    public double getZ() {
+        return z;
+    }
+    
+    public float getYaw() {
+        return yaw;
+    }
+    
+    public float getPitch() {
+        return pitch;
+    }
+    
+    /**
+     * Convert to a Bukkit Location in the specified world.
+     * 
+     * @param world The world for the location
+     * @return A Bukkit Location object
+     */
+    public Location toLocation(World world) {
+        return new Location(world, x, y, z, yaw, pitch);
+    }
+    
+    /**
+     * Create a spawn point offset from the arena origin.
+     * 
+     * @param originX Arena origin X
+     * @param originY Arena origin Y
+     * @param originZ Arena origin Z
+     * @return A new SpawnPoint with absolute coordinates
+     */
+    public SpawnPoint withOffset(double originX, double originY, double originZ) {
+        return new SpawnPoint(
+            x + originX,
+            y + originY,
+            z + originZ,
+            yaw,
+            pitch
+        );
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("SpawnPoint{x=%.1f, y=%.1f, z=%.1f, yaw=%.1f, pitch=%.1f}",
+                x, y, z, yaw, pitch);
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/constants/GameConfig.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/constants/GameConfig.java
@@ -19,6 +19,9 @@ public final class GameConfig {
     // ==================== Game Types ====================
     
     public static final String GAME_TYPE_PVP = "pvp";
+    public static final String GAME_TYPE_SKY_TILES = "sky_tiles";
+    public static final String GAME_TYPE_WOOL_WARS = "wool_wars";
+    public static final String GAME_TYPE_BRIDGE = "bridge";
     public static final String GAME_TYPE_BEDWARS = "bedwars";
     public static final String GAME_TYPE_CTF = "ctf";
     
@@ -27,6 +30,9 @@ public final class GameConfig {
      */
     public static final String[] GAME_TYPES = {
         GAME_TYPE_PVP,
+        GAME_TYPE_SKY_TILES,
+        GAME_TYPE_WOOL_WARS,
+        GAME_TYPE_BRIDGE,
         GAME_TYPE_BEDWARS,
         GAME_TYPE_CTF
     };
@@ -35,6 +41,9 @@ public final class GameConfig {
     // Note: These values should match the backend, but the backend is the source of truth
     
     public static final int PVP_TOKENS_PER_TEAM = 1;
+    public static final int SKY_TILES_TOKENS_PER_TEAM = 1;
+    public static final int WOOL_WARS_TOKENS_PER_TEAM = 4;
+    public static final int BRIDGE_TOKENS_PER_TEAM = 1;
     public static final int BEDWARS_TOKENS_PER_TEAM = 4;
     public static final int CTF_TOKENS_PER_TEAM = 5;
     
@@ -46,6 +55,12 @@ public final class GameConfig {
         switch (gameType) {
             case GAME_TYPE_PVP:
                 return PVP_TOKENS_PER_TEAM;
+            case GAME_TYPE_SKY_TILES:
+                return SKY_TILES_TOKENS_PER_TEAM;
+            case GAME_TYPE_WOOL_WARS:
+                return WOOL_WARS_TOKENS_PER_TEAM;
+            case GAME_TYPE_BRIDGE:
+                return BRIDGE_TOKENS_PER_TEAM;
             case GAME_TYPE_BEDWARS:
                 return BEDWARS_TOKENS_PER_TEAM;
             case GAME_TYPE_CTF:
@@ -53,6 +68,38 @@ public final class GameConfig {
             default:
                 return 1; // Default to 1 for unknown types
         }
+    }
+    
+    // ==================== Arena Defaults ====================
+    
+    /**
+     * Get the default arena name for a game type
+     */
+    public static String getDefaultArena(String gameType) {
+        switch (gameType) {
+            case GAME_TYPE_PVP:
+                return "pvp";
+            case GAME_TYPE_SKY_TILES:
+                return "sky_tiles";
+            case GAME_TYPE_WOOL_WARS:
+                return "wool_wars";
+            case GAME_TYPE_BRIDGE:
+                return "bridge";
+            default:
+                return "pvp"; // Default to pvp arena
+        }
+    }
+    
+    /**
+     * Check if a game type is valid
+     */
+    public static boolean isValidGameType(String gameType) {
+        for (String type : GAME_TYPES) {
+            if (type.equals(gameType)) {
+                return true;
+            }
+        }
+        return false;
     }
     
     // ==================== Match Statuses ====================

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/BaseGame.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/BaseGame.java
@@ -1,0 +1,387 @@
+package ai.blockwarriors.beacon.game;
+
+import ai.blockwarriors.beacon.arena.ArenaConfig;
+
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * Abstract base class for all game implementations.
+ * 
+ * Game developers must extend this class to create new game types.
+ * The game lifecycle is:
+ * 1. Constructor - basic setup
+ * 2. initialize() - called once when game is created
+ * 3. start() - called to begin gameplay
+ * 4. [game events] - handlePlayerDeath(), handleObjective(), etc.
+ * 5. checkWinCondition() - checked after events
+ * 6. cleanup() - called when game ends
+ * 
+ * @see GameRegistry for registering game implementations
+ */
+public abstract class BaseGame {
+    
+    protected static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    /** The type of this game (e.g., "pvp", "sky_tiles") */
+    protected final String gameType;
+    
+    /** Unique identifier for this match instance */
+    protected final String matchId;
+    
+    /** Reference to the plugin for scheduling tasks */
+    protected final JavaPlugin plugin;
+    
+    /** The world this game is running in */
+    protected World world;
+    
+    /** Arena configuration (spawns, boundaries, objectives) */
+    protected ArenaConfig arenaConfig;
+    
+    /** Current game state */
+    protected GameState state = GameState.INITIALIZING;
+    
+    /** All players in this game */
+    protected final Set<UUID> players = new HashSet<>();
+    
+    /** Blue team players */
+    protected final List<UUID> blueTeam = new ArrayList<>();
+    
+    /** Red team players */
+    protected final List<UUID> redTeam = new ArrayList<>();
+    
+    /** Players who have disconnected (for grace period tracking) */
+    protected final Map<UUID, Long> disconnectedPlayers = new HashMap<>();
+    
+    /** Time when the game started (for telemetry) */
+    protected long startTime;
+    
+    /** Time when the game ended */
+    protected long endTime;
+    
+    /** Winner player ID (null if no winner yet or draw) */
+    protected UUID winnerId;
+    
+    /**
+     * Create a new game instance.
+     * 
+     * @param plugin The JavaPlugin instance
+     * @param gameType The type of game (must match registered type)
+     * @param matchId Unique match identifier from backend
+     */
+    protected BaseGame(JavaPlugin plugin, String gameType, String matchId) {
+        this.plugin = plugin;
+        this.gameType = gameType;
+        this.matchId = matchId;
+    }
+    
+    // ==================== Abstract Lifecycle Methods ====================
+    
+    /**
+     * Initialize the game. Called once after construction.
+     * Set up any game-specific state, load resources, etc.
+     * 
+     * @param world The world the game will run in
+     * @param arenaConfig Arena configuration with spawns and boundaries
+     * @param blueTeamPlayers Players on the blue team
+     * @param redTeamPlayers Players on the red team
+     */
+    public abstract void initialize(World world, ArenaConfig arenaConfig,
+                                   List<Player> blueTeamPlayers, List<Player> redTeamPlayers);
+    
+    /**
+     * Start the game. Called after all players are teleported and ready.
+     * Begin countdown, enable PvP, spawn items, etc.
+     */
+    public abstract void start();
+    
+    /**
+     * Handle a player death event.
+     * 
+     * @param deadPlayer The player who died
+     * @param killer The killer (null if environmental death)
+     * @return true if the death was handled, false to let default behavior occur
+     */
+    public abstract boolean handlePlayerDeath(Player deadPlayer, Player killer);
+    
+    /**
+     * Handle a game-specific objective event.
+     * Each game defines what "objectives" mean (e.g., bed destroyed, flag captured).
+     * 
+     * @param objectiveType Type of objective (game-specific)
+     * @param player Player who triggered the objective
+     * @param data Additional objective data (game-specific)
+     * @return true if objective was handled
+     */
+    public abstract boolean handleObjective(String objectiveType, Player player, Map<String, Object> data);
+    
+    /**
+     * Check if win conditions have been met.
+     * Called after significant events (deaths, objectives).
+     * 
+     * @return true if game should end
+     */
+    public abstract boolean checkWinCondition();
+    
+    /**
+     * Get the current game state for telemetry.
+     * Returns game-specific data to be sent to the backend.
+     * 
+     * @return Map of game state data
+     */
+    public abstract Map<String, Object> getGameState();
+    
+    /**
+     * Clean up the game. Called when game ends.
+     * Cancel tasks, clear scoreboards, reset state, etc.
+     */
+    public abstract void cleanup();
+    
+    // ==================== Disconnect Handling ====================
+    
+    /**
+     * Handle player disconnect. Game decides outcome based on policy.
+     * 
+     * @param playerId UUID of disconnected player
+     * @param reason Why the player disconnected
+     * @return Result indicating how to proceed
+     */
+    public abstract DisconnectResult handlePlayerDisconnect(UUID playerId, DisconnectReason reason);
+    
+    /**
+     * Handle player reconnect during grace period.
+     * 
+     * @param playerId UUID of reconnecting player
+     * @return true if reconnect was successful
+     */
+    public abstract boolean handlePlayerReconnect(UUID playerId);
+    
+    /**
+     * Get the disconnect policy for this game type.
+     * 
+     * @return Disconnect policy configuration
+     */
+    public abstract DisconnectPolicy getDisconnectPolicy();
+    
+    // ==================== Common Implementations ====================
+    
+    /**
+     * Get the game type identifier.
+     */
+    public String getGameType() {
+        return gameType;
+    }
+    
+    /**
+     * Get the match ID.
+     */
+    public String getMatchId() {
+        return matchId;
+    }
+    
+    /**
+     * Get the current game state.
+     */
+    public GameState getState() {
+        return state;
+    }
+    
+    /**
+     * Set the game state.
+     */
+    protected void setState(GameState newState) {
+        GameState oldState = this.state;
+        this.state = newState;
+        LOGGER.info(String.format("Match %s: State changed %s -> %s", matchId, oldState, newState));
+    }
+    
+    /**
+     * Get all players in this game.
+     */
+    public Set<UUID> getPlayers() {
+        return Collections.unmodifiableSet(players);
+    }
+    
+    /**
+     * Get blue team players.
+     */
+    public List<UUID> getBlueTeam() {
+        return Collections.unmodifiableList(blueTeam);
+    }
+    
+    /**
+     * Get red team players.
+     */
+    public List<UUID> getRedTeam() {
+        return Collections.unmodifiableList(redTeam);
+    }
+    
+    /**
+     * Get the world this game is running in.
+     */
+    public World getWorld() {
+        return world;
+    }
+    
+    /**
+     * Get the arena configuration.
+     */
+    public ArenaConfig getArenaConfig() {
+        return arenaConfig;
+    }
+    
+    /**
+     * Check if a player is in this game.
+     */
+    public boolean hasPlayer(UUID playerId) {
+        return players.contains(playerId);
+    }
+    
+    /**
+     * Get the team for a player.
+     * 
+     * @return "blue", "red", or null if not in a team
+     */
+    public String getTeamForPlayer(UUID playerId) {
+        if (blueTeam.contains(playerId)) {
+            return "blue";
+        } else if (redTeam.contains(playerId)) {
+            return "red";
+        }
+        return null;
+    }
+    
+    /**
+     * Check if a player is currently disconnected (in grace period).
+     */
+    public boolean isPlayerDisconnected(UUID playerId) {
+        return disconnectedPlayers.containsKey(playerId);
+    }
+    
+    /**
+     * Get the winner's UUID.
+     * 
+     * @return Winner UUID, or null if no winner yet
+     */
+    public UUID getWinnerId() {
+        return winnerId;
+    }
+    
+    /**
+     * Get the game duration in milliseconds.
+     * Returns 0 if game hasn't started.
+     */
+    public long getDurationMillis() {
+        if (startTime == 0) {
+            return 0;
+        }
+        long end = endTime > 0 ? endTime : System.currentTimeMillis();
+        return end - startTime;
+    }
+    
+    /**
+     * Check if the game is currently active (can receive events).
+     */
+    public boolean isActive() {
+        return state == GameState.IN_PROGRESS || state == GameState.PAUSED;
+    }
+    
+    /**
+     * Check if the game has ended.
+     */
+    public boolean hasEnded() {
+        return state == GameState.FINISHED || state == GameState.TERMINATED;
+    }
+    
+    // ==================== Utility Methods ====================
+    
+    /**
+     * Get players on the opposing team.
+     * 
+     * @param playerId Player to find opponents for
+     * @return List of opponent UUIDs
+     */
+    protected List<UUID> getOpponents(UUID playerId) {
+        if (blueTeam.contains(playerId)) {
+            return new ArrayList<>(redTeam);
+        } else if (redTeam.contains(playerId)) {
+            return new ArrayList<>(blueTeam);
+        }
+        return new ArrayList<>();
+    }
+    
+    /**
+     * Get teammates of a player (excluding the player themselves).
+     * 
+     * @param playerId Player to find teammates for
+     * @return List of teammate UUIDs
+     */
+    protected List<UUID> getTeammates(UUID playerId) {
+        List<UUID> teammates = new ArrayList<>();
+        if (blueTeam.contains(playerId)) {
+            for (UUID id : blueTeam) {
+                if (!id.equals(playerId)) {
+                    teammates.add(id);
+                }
+            }
+        } else if (redTeam.contains(playerId)) {
+            for (UUID id : redTeam) {
+                if (!id.equals(playerId)) {
+                    teammates.add(id);
+                }
+            }
+        }
+        return teammates;
+    }
+    
+    /**
+     * Count active (non-disconnected) players on a team.
+     * 
+     * @param team "blue" or "red"
+     * @return Number of active players
+     */
+    protected int countActivePlayers(String team) {
+        List<UUID> teamPlayers = "blue".equals(team) ? blueTeam : redTeam;
+        int count = 0;
+        for (UUID playerId : teamPlayers) {
+            if (!disconnectedPlayers.containsKey(playerId)) {
+                count++;
+            }
+        }
+        return count;
+    }
+    
+    /**
+     * End the game with a winner.
+     * 
+     * @param winner UUID of winning player (null for draw)
+     */
+    protected void endGame(UUID winner) {
+        this.winnerId = winner;
+        this.endTime = System.currentTimeMillis();
+        setState(GameState.FINISHED);
+        LOGGER.info(String.format("Match %s ended. Winner: %s, Duration: %dms",
+                matchId, winner != null ? winner.toString() : "none", getDurationMillis()));
+    }
+    
+    /**
+     * Terminate the game early (cancelled, error, etc.).
+     * 
+     * @param reason Reason for termination
+     */
+    protected void terminateGame(String reason) {
+        this.endTime = System.currentTimeMillis();
+        setState(GameState.TERMINATED);
+        LOGGER.warning(String.format("Match %s terminated: %s", matchId, reason));
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("BaseGame{type=%s, matchId=%s, state=%s, players=%d}",
+                gameType, matchId, state, players.size());
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/BaseGame.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/BaseGame.java
@@ -305,7 +305,7 @@ public abstract class BaseGame {
      * @param playerId Player to find opponents for
      * @return List of opponent UUIDs
      */
-    protected List<UUID> getOpponents(UUID playerId) {
+    public List<UUID> getOpponents(UUID playerId) {
         if (blueTeam.contains(playerId)) {
             return new ArrayList<>(redTeam);
         } else if (redTeam.contains(playerId)) {

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/DisconnectPolicy.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/DisconnectPolicy.java
@@ -1,0 +1,81 @@
+package ai.blockwarriors.beacon.game;
+
+/**
+ * Configuration for how a game handles player disconnects.
+ * Each game type can define its own policy.
+ */
+public class DisconnectPolicy {
+    
+    /** Time in seconds to wait for reconnection (0 = instant forfeit) */
+    private final int gracePeriodSeconds;
+    
+    /** Minimum players per team before forfeit is triggered */
+    private final int minPlayersPerTeam;
+    
+    /** Whether disconnected players can rejoin during grace period */
+    private final boolean allowReconnect;
+    
+    /**
+     * Create a disconnect policy with all parameters.
+     * 
+     * @param gracePeriodSeconds Time to wait for reconnection (0 for instant forfeit)
+     * @param minPlayersPerTeam Minimum players needed per team to continue
+     * @param allowReconnect Whether players can reconnect during grace period
+     */
+    public DisconnectPolicy(int gracePeriodSeconds, int minPlayersPerTeam, boolean allowReconnect) {
+        this.gracePeriodSeconds = gracePeriodSeconds;
+        this.minPlayersPerTeam = minPlayersPerTeam;
+        this.allowReconnect = allowReconnect;
+    }
+    
+    /**
+     * Create an instant forfeit policy (no grace period, no reconnect).
+     */
+    public static DisconnectPolicy instantForfeit() {
+        return new DisconnectPolicy(0, 1, false);
+    }
+    
+    /**
+     * Create a grace period policy.
+     * 
+     * @param seconds Grace period in seconds
+     */
+    public static DisconnectPolicy withGracePeriod(int seconds) {
+        return new DisconnectPolicy(seconds, 1, true);
+    }
+    
+    /**
+     * Create a team game policy that allows continuing with fewer players.
+     * 
+     * @param gracePeriodSeconds Grace period for reconnection
+     * @param minPlayersPerTeam Minimum players required per team
+     */
+    public static DisconnectPolicy teamGame(int gracePeriodSeconds, int minPlayersPerTeam) {
+        return new DisconnectPolicy(gracePeriodSeconds, minPlayersPerTeam, true);
+    }
+    
+    public int getGracePeriodSeconds() {
+        return gracePeriodSeconds;
+    }
+    
+    public int getMinPlayersPerTeam() {
+        return minPlayersPerTeam;
+    }
+    
+    public boolean isAllowReconnect() {
+        return allowReconnect;
+    }
+    
+    /**
+     * Check if this policy requires immediate forfeit on disconnect.
+     */
+    public boolean isInstantForfeit() {
+        return gracePeriodSeconds == 0;
+    }
+    
+    @Override
+    public String toString() {
+        return String.format("DisconnectPolicy{grace=%ds, minPlayers=%d, reconnect=%s}",
+                gracePeriodSeconds, minPlayersPerTeam, allowReconnect);
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/DisconnectReason.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/DisconnectReason.java
@@ -1,0 +1,15 @@
+package ai.blockwarriors.beacon.game;
+
+/**
+ * Reasons why a player may disconnect during a match.
+ */
+public enum DisconnectReason {
+    /** Player voluntarily quit the game */
+    QUIT,
+    
+    /** Player was kicked by server/admin */
+    KICK,
+    
+    /** Player connection timed out */
+    TIMEOUT
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/DisconnectResult.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/DisconnectResult.java
@@ -1,0 +1,19 @@
+package ai.blockwarriors.beacon.game;
+
+/**
+ * Result of handling a player disconnect.
+ * Each game type decides how to respond to disconnects.
+ */
+public enum DisconnectResult {
+    /** Other team wins immediately */
+    FORFEIT,
+    
+    /** Wait for player to reconnect within grace period */
+    GRACE_PERIOD,
+    
+    /** Game continues with remaining players (team games) */
+    CONTINUE,
+    
+    /** Game is cancelled (e.g., not enough players) */
+    GAME_CANCELLED
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/GameFactory.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/GameFactory.java
@@ -1,0 +1,23 @@
+package ai.blockwarriors.beacon.game;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+/**
+ * Factory interface for creating game instances.
+ * 
+ * Each game type must provide a factory that can create new game instances.
+ * The factory is registered with GameRegistry and used by MatchPollingService
+ * to instantiate games when matches are ready to start.
+ */
+@FunctionalInterface
+public interface GameFactory {
+    
+    /**
+     * Create a new game instance.
+     * 
+     * @param plugin The JavaPlugin instance for scheduling tasks
+     * @param matchId Unique match identifier from the backend
+     * @return A new BaseGame instance ready to be initialized
+     */
+    BaseGame createGame(JavaPlugin plugin, String matchId);
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/GameRegistry.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/GameRegistry.java
@@ -1,0 +1,273 @@
+package ai.blockwarriors.beacon.game;
+
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * Singleton registry for game type implementations.
+ * 
+ * Maps game type strings (e.g., "pvp", "sky_tiles") to GameFactory instances
+ * that can create game objects. Games are registered at plugin startup and
+ * instantiated by MatchPollingService when matches are ready to start.
+ * 
+ * Usage:
+ * <pre>
+ * // Register a game type (typically in Plugin.onEnable())
+ * GameRegistry.getInstance().registerGame("pvp", PvPGame::new);
+ * 
+ * // Create a game instance
+ * BaseGame game = GameRegistry.getInstance().createGame("pvp", plugin, matchId);
+ * </pre>
+ */
+public class GameRegistry {
+    
+    private static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    /** Singleton instance */
+    private static GameRegistry instance;
+    
+    /** Map of game type to factory */
+    private final Map<String, GameFactory> factories = new HashMap<>();
+    
+    /** Map of game type to metadata */
+    private final Map<String, GameMetadata> metadata = new HashMap<>();
+    
+    /** Private constructor for singleton */
+    private GameRegistry() {
+        LOGGER.info("GameRegistry initialized");
+    }
+    
+    /**
+     * Get the singleton GameRegistry instance.
+     * Creates the instance if it doesn't exist.
+     */
+    public static synchronized GameRegistry getInstance() {
+        if (instance == null) {
+            instance = new GameRegistry();
+        }
+        return instance;
+    }
+    
+    /**
+     * Register a game type with its factory.
+     * 
+     * @param gameType Unique game type identifier (e.g., "pvp", "sky_tiles")
+     * @param factory Factory function to create game instances
+     * @throws IllegalArgumentException if gameType is null or empty
+     * @throws IllegalStateException if gameType is already registered
+     */
+    public void registerGame(String gameType, GameFactory factory) {
+        registerGame(gameType, factory, null);
+    }
+    
+    /**
+     * Register a game type with its factory and metadata.
+     * 
+     * @param gameType Unique game type identifier
+     * @param factory Factory function to create game instances
+     * @param meta Optional metadata about the game type
+     */
+    public void registerGame(String gameType, GameFactory factory, GameMetadata meta) {
+        if (gameType == null || gameType.isEmpty()) {
+            throw new IllegalArgumentException("gameType cannot be null or empty");
+        }
+        if (factory == null) {
+            throw new IllegalArgumentException("factory cannot be null");
+        }
+        if (factories.containsKey(gameType)) {
+            throw new IllegalStateException("Game type '" + gameType + "' is already registered");
+        }
+        
+        factories.put(gameType, factory);
+        if (meta != null) {
+            metadata.put(gameType, meta);
+        }
+        
+        LOGGER.info("Registered game type: " + gameType);
+    }
+    
+    /**
+     * Unregister a game type.
+     * Typically used during plugin disable or for testing.
+     * 
+     * @param gameType Game type to unregister
+     * @return true if game type was registered and removed
+     */
+    public boolean unregisterGame(String gameType) {
+        GameFactory removed = factories.remove(gameType);
+        metadata.remove(gameType);
+        if (removed != null) {
+            LOGGER.info("Unregistered game type: " + gameType);
+            return true;
+        }
+        return false;
+    }
+    
+    /**
+     * Create a new game instance for the specified type.
+     * 
+     * @param gameType Type of game to create
+     * @param plugin JavaPlugin instance for scheduling
+     * @param matchId Unique match identifier
+     * @return New BaseGame instance, or null if game type not found
+     */
+    public BaseGame createGame(String gameType, JavaPlugin plugin, String matchId) {
+        GameFactory factory = factories.get(gameType);
+        if (factory == null) {
+            LOGGER.warning("No factory registered for game type: " + gameType);
+            return null;
+        }
+        
+        try {
+            BaseGame game = factory.createGame(plugin, matchId);
+            LOGGER.info("Created game instance: " + gameType + " for match " + matchId);
+            return game;
+        } catch (Exception e) {
+            LOGGER.severe("Failed to create game " + gameType + ": " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
+    
+    /**
+     * Check if a game type is registered.
+     */
+    public boolean isRegistered(String gameType) {
+        return factories.containsKey(gameType);
+    }
+    
+    /**
+     * Get all registered game types.
+     */
+    public Set<String> getRegisteredTypes() {
+        return Collections.unmodifiableSet(factories.keySet());
+    }
+    
+    /**
+     * Get metadata for a game type.
+     * 
+     * @param gameType Game type to look up
+     * @return Metadata, or null if not available
+     */
+    public GameMetadata getMetadata(String gameType) {
+        return metadata.get(gameType);
+    }
+    
+    /**
+     * Get the number of registered game types.
+     */
+    public int getRegisteredCount() {
+        return factories.size();
+    }
+    
+    /**
+     * Clear all registered games.
+     * Typically used during plugin disable or for testing.
+     */
+    public void clearAll() {
+        int count = factories.size();
+        factories.clear();
+        metadata.clear();
+        LOGGER.info("Cleared " + count + " registered game types");
+    }
+    
+    /**
+     * Reset the singleton instance.
+     * Used for testing purposes only.
+     */
+    public static synchronized void resetInstance() {
+        if (instance != null) {
+            instance.clearAll();
+            instance = null;
+        }
+    }
+    
+    /**
+     * Metadata about a game type.
+     * Optional information that can be used for UI display, validation, etc.
+     */
+    public static class GameMetadata {
+        private final String displayName;
+        private final String description;
+        private final int playersPerTeam;
+        private final int teamCount;
+        private final String defaultArena;
+        
+        public GameMetadata(String displayName, String description,
+                           int playersPerTeam, int teamCount, String defaultArena) {
+            this.displayName = displayName;
+            this.description = description;
+            this.playersPerTeam = playersPerTeam;
+            this.teamCount = teamCount;
+            this.defaultArena = defaultArena;
+        }
+        
+        public static Builder builder() {
+            return new Builder();
+        }
+        
+        public String getDisplayName() {
+            return displayName;
+        }
+        
+        public String getDescription() {
+            return description;
+        }
+        
+        public int getPlayersPerTeam() {
+            return playersPerTeam;
+        }
+        
+        public int getTeamCount() {
+            return teamCount;
+        }
+        
+        public int getTotalPlayers() {
+            return playersPerTeam * teamCount;
+        }
+        
+        public String getDefaultArena() {
+            return defaultArena;
+        }
+        
+        public static class Builder {
+            private String displayName;
+            private String description;
+            private int playersPerTeam = 1;
+            private int teamCount = 2;
+            private String defaultArena;
+            
+            public Builder displayName(String name) {
+                this.displayName = name;
+                return this;
+            }
+            
+            public Builder description(String desc) {
+                this.description = desc;
+                return this;
+            }
+            
+            public Builder playersPerTeam(int count) {
+                this.playersPerTeam = count;
+                return this;
+            }
+            
+            public Builder teamCount(int count) {
+                this.teamCount = count;
+                return this;
+            }
+            
+            public Builder defaultArena(String arena) {
+                this.defaultArena = arena;
+                return this;
+            }
+            
+            public GameMetadata build() {
+                return new GameMetadata(displayName, description,
+                        playersPerTeam, teamCount, defaultArena);
+            }
+        }
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/GameState.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/GameState.java
@@ -1,0 +1,27 @@
+package ai.blockwarriors.beacon.game;
+
+/**
+ * Represents the current state of a game instance.
+ */
+public enum GameState {
+    /** Game is being set up, waiting for initialization */
+    INITIALIZING,
+    
+    /** Game is initialized and ready to start */
+    READY,
+    
+    /** Pre-game countdown is active */
+    COUNTDOWN,
+    
+    /** Game is actively being played */
+    IN_PROGRESS,
+    
+    /** Game is paused (e.g., player disconnected in grace period) */
+    PAUSED,
+    
+    /** Game has ended normally with a winner */
+    FINISHED,
+    
+    /** Game was terminated early (cancelled, error, etc.) */
+    TERMINATED
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/GracePeriodTracker.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/GracePeriodTracker.java
@@ -1,0 +1,235 @@
+package ai.blockwarriors.beacon.game;
+
+import org.bukkit.Bukkit;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+/**
+ * Tracks grace periods for disconnected players and handles timeouts.
+ * 
+ * When a player disconnects with a grace period policy, this tracker:
+ * 1. Records the disconnect time
+ * 2. Schedules a timeout task
+ * 3. Calls the timeout handler when grace period expires
+ * 4. Handles reconnection by canceling the timeout
+ */
+public class GracePeriodTracker {
+    
+    private static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    /**
+     * Information about a disconnected player in grace period.
+     */
+    public static class DisconnectInfo {
+        public final UUID playerId;
+        public final String matchId;
+        public final long disconnectTime;
+        public final long gracePeriodEnds;
+        public final DisconnectReason reason;
+        public final BukkitTask timeoutTask;
+        
+        public DisconnectInfo(UUID playerId, String matchId, long disconnectTime,
+                            int gracePeriodSeconds, DisconnectReason reason, BukkitTask timeoutTask) {
+            this.playerId = playerId;
+            this.matchId = matchId;
+            this.disconnectTime = disconnectTime;
+            this.gracePeriodEnds = disconnectTime + (gracePeriodSeconds * 1000L);
+            this.reason = reason;
+            this.timeoutTask = timeoutTask;
+        }
+        
+        /**
+         * Get remaining grace period time in milliseconds.
+         */
+        public long getRemainingMs() {
+            return Math.max(0, gracePeriodEnds - System.currentTimeMillis());
+        }
+        
+        /**
+         * Check if grace period has expired.
+         */
+        public boolean isExpired() {
+            return System.currentTimeMillis() >= gracePeriodEnds;
+        }
+        
+        /**
+         * Convert to telemetry-friendly map.
+         */
+        public Map<String, Object> toMap() {
+            Map<String, Object> map = new HashMap<>();
+            map.put("playerId", playerId.toString());
+            map.put("matchId", matchId);
+            map.put("disconnectTime", disconnectTime);
+            map.put("gracePeriodEnds", gracePeriodEnds);
+            map.put("reason", reason.name());
+            map.put("remainingMs", getRemainingMs());
+            return map;
+        }
+    }
+    
+    private final JavaPlugin plugin;
+    private final Map<UUID, DisconnectInfo> disconnectedPlayers = new ConcurrentHashMap<>();
+    private final Map<String, Set<UUID>> matchDisconnects = new ConcurrentHashMap<>();
+    
+    public GracePeriodTracker(JavaPlugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    /**
+     * Start tracking a disconnected player with a grace period.
+     * 
+     * @param playerId UUID of the disconnected player
+     * @param matchId Match the player was in
+     * @param gracePeriodSeconds Time to wait for reconnection
+     * @param reason Why the player disconnected
+     * @param onTimeout Callback when grace period expires (runs on main thread)
+     */
+    public void startGracePeriod(UUID playerId, String matchId, int gracePeriodSeconds,
+                                DisconnectReason reason, Consumer<UUID> onTimeout) {
+        // Cancel existing grace period if any
+        cancelGracePeriod(playerId);
+        
+        long disconnectTime = System.currentTimeMillis();
+        
+        // Schedule timeout task
+        BukkitTask timeoutTask = Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            LOGGER.info("Grace period expired for player " + playerId + " in match " + matchId);
+            
+            // Remove tracking
+            disconnectedPlayers.remove(playerId);
+            Set<UUID> matchSet = matchDisconnects.get(matchId);
+            if (matchSet != null) {
+                matchSet.remove(playerId);
+                if (matchSet.isEmpty()) {
+                    matchDisconnects.remove(matchId);
+                }
+            }
+            
+            // Call timeout handler
+            if (onTimeout != null) {
+                onTimeout.accept(playerId);
+            }
+        }, gracePeriodSeconds * 20L); // Convert seconds to ticks
+        
+        // Store disconnect info
+        DisconnectInfo info = new DisconnectInfo(playerId, matchId, disconnectTime,
+                gracePeriodSeconds, reason, timeoutTask);
+        disconnectedPlayers.put(playerId, info);
+        
+        matchDisconnects.computeIfAbsent(matchId, k -> ConcurrentHashMap.newKeySet()).add(playerId);
+        
+        LOGGER.info("Started " + gracePeriodSeconds + "s grace period for player " + playerId + 
+                   " in match " + matchId);
+    }
+    
+    /**
+     * Cancel a player's grace period (e.g., they reconnected).
+     * 
+     * @param playerId UUID of the player
+     * @return true if a grace period was active and cancelled
+     */
+    public boolean cancelGracePeriod(UUID playerId) {
+        DisconnectInfo info = disconnectedPlayers.remove(playerId);
+        if (info == null) {
+            return false;
+        }
+        
+        // Cancel the timeout task
+        if (info.timeoutTask != null && !info.timeoutTask.isCancelled()) {
+            info.timeoutTask.cancel();
+        }
+        
+        // Remove from match tracking
+        Set<UUID> matchSet = matchDisconnects.get(info.matchId);
+        if (matchSet != null) {
+            matchSet.remove(playerId);
+            if (matchSet.isEmpty()) {
+                matchDisconnects.remove(info.matchId);
+            }
+        }
+        
+        LOGGER.info("Cancelled grace period for player " + playerId);
+        return true;
+    }
+    
+    /**
+     * Check if a player is in a grace period.
+     */
+    public boolean isInGracePeriod(UUID playerId) {
+        return disconnectedPlayers.containsKey(playerId);
+    }
+    
+    /**
+     * Get disconnect info for a player.
+     */
+    public DisconnectInfo getDisconnectInfo(UUID playerId) {
+        return disconnectedPlayers.get(playerId);
+    }
+    
+    /**
+     * Get all disconnected players for a match.
+     */
+    public Set<UUID> getDisconnectedPlayers(String matchId) {
+        Set<UUID> set = matchDisconnects.get(matchId);
+        return set != null ? new HashSet<>(set) : new HashSet<>();
+    }
+    
+    /**
+     * Get disconnect info for all players in a match.
+     */
+    public List<DisconnectInfo> getMatchDisconnects(String matchId) {
+        List<DisconnectInfo> infos = new ArrayList<>();
+        Set<UUID> playerIds = matchDisconnects.get(matchId);
+        if (playerIds != null) {
+            for (UUID playerId : playerIds) {
+                DisconnectInfo info = disconnectedPlayers.get(playerId);
+                if (info != null) {
+                    infos.add(info);
+                }
+            }
+        }
+        return infos;
+    }
+    
+    /**
+     * Clear all grace periods for a match (e.g., match ended).
+     */
+    public void clearMatch(String matchId) {
+        Set<UUID> playerIds = matchDisconnects.remove(matchId);
+        if (playerIds != null) {
+            for (UUID playerId : playerIds) {
+                DisconnectInfo info = disconnectedPlayers.remove(playerId);
+                if (info != null && info.timeoutTask != null) {
+                    info.timeoutTask.cancel();
+                }
+            }
+            LOGGER.info("Cleared " + playerIds.size() + " grace periods for match " + matchId);
+        }
+    }
+    
+    /**
+     * Clear all tracked grace periods.
+     */
+    public void clearAll() {
+        for (DisconnectInfo info : disconnectedPlayers.values()) {
+            if (info.timeoutTask != null) {
+                info.timeoutTask.cancel();
+            }
+        }
+        disconnectedPlayers.clear();
+        matchDisconnects.clear();
+        LOGGER.info("Cleared all grace periods");
+    }
+    
+    /**
+     * Get count of players currently in grace period.
+     */
+    public int getActiveCount() {
+        return disconnectedPlayers.size();
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/impl/PvPGame.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/impl/PvPGame.java
@@ -106,7 +106,7 @@ public class PvPGame extends BaseGame {
             return;
         }
         
-        setState(GameState.STARTING);
+        setState(GameState.COUNTDOWN);
         
         // Start countdown
         startCountdown();

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/impl/PvPGame.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/impl/PvPGame.java
@@ -1,0 +1,434 @@
+package ai.blockwarriors.beacon.game.impl;
+
+import ai.blockwarriors.beacon.arena.ArenaConfig;
+import ai.blockwarriors.beacon.arena.SpawnPoint;
+import ai.blockwarriors.beacon.constants.GameConfig;
+import ai.blockwarriors.beacon.game.*;
+
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.Sound;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
+import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.scheduler.BukkitTask;
+
+import java.util.*;
+
+/**
+ * Reference implementation of a 1v1 PvP game.
+ * 
+ * Rules:
+ * - Two players fight until one dies
+ * - First player to kill the other wins
+ * - Disconnecting causes immediate forfeit
+ * - No respawns - single elimination
+ * 
+ * This serves as a reference for implementing other game types.
+ */
+public class PvPGame extends BaseGame {
+    
+    /** Default disconnect policy: instant forfeit */
+    private static final DisconnectPolicy DISCONNECT_POLICY = DisconnectPolicy.instantForfeit();
+    
+    /** Countdown duration before match starts */
+    private static final int COUNTDOWN_SECONDS = 5;
+    
+    /** Kill counts per player */
+    private final Map<UUID, Integer> kills = new HashMap<>();
+    
+    /** Death counts per player */
+    private final Map<UUID, Integer> deaths = new HashMap<>();
+    
+    /** Damage dealt per player */
+    private final Map<UUID, Double> damageDealt = new HashMap<>();
+    
+    /** Countdown task */
+    private BukkitTask countdownTask;
+    
+    /** Whether PvP is enabled */
+    private boolean pvpEnabled = false;
+    
+    /**
+     * Create a new PvP game instance.
+     * 
+     * @param plugin The JavaPlugin instance
+     * @param matchId Unique match identifier
+     */
+    public PvPGame(JavaPlugin plugin, String matchId) {
+        super(plugin, GameConfig.GAME_TYPE_PVP, matchId);
+    }
+    
+    // ==================== Lifecycle Methods ====================
+    
+    @Override
+    public void initialize(World world, ArenaConfig arenaConfig,
+                          List<Player> blueTeamPlayers, List<Player> redTeamPlayers) {
+        this.world = world;
+        this.arenaConfig = arenaConfig;
+        
+        // Register players
+        for (Player p : blueTeamPlayers) {
+            players.add(p.getUniqueId());
+            blueTeam.add(p.getUniqueId());
+            initPlayerStats(p.getUniqueId());
+        }
+        for (Player p : redTeamPlayers) {
+            players.add(p.getUniqueId());
+            redTeam.add(p.getUniqueId());
+            initPlayerStats(p.getUniqueId());
+        }
+        
+        // Teleport players to spawn points
+        teleportPlayersToSpawns(blueTeamPlayers, redTeamPlayers);
+        
+        // Set up players (game mode, inventory, health)
+        for (Player p : blueTeamPlayers) {
+            setupPlayer(p);
+        }
+        for (Player p : redTeamPlayers) {
+            setupPlayer(p);
+        }
+        
+        setState(GameState.READY);
+        LOGGER.info("PvP game initialized for match " + matchId + " with " + 
+                   blueTeamPlayers.size() + "v" + redTeamPlayers.size() + " players");
+    }
+    
+    @Override
+    public void start() {
+        if (state != GameState.READY) {
+            LOGGER.warning("Cannot start game - not in READY state (current: " + state + ")");
+            return;
+        }
+        
+        setState(GameState.STARTING);
+        
+        // Start countdown
+        startCountdown();
+    }
+    
+    @Override
+    public boolean handlePlayerDeath(Player deadPlayer, Player killer) {
+        if (!isActive()) {
+            return false;
+        }
+        
+        UUID deadId = deadPlayer.getUniqueId();
+        
+        // Increment death count
+        deaths.merge(deadId, 1, Integer::sum);
+        
+        // If there was a killer, increment their kill count
+        if (killer != null) {
+            UUID killerId = killer.getUniqueId();
+            kills.merge(killerId, 1, Integer::sum);
+            
+            // Announce kill
+            broadcastMessage("§c" + deadPlayer.getName() + " §7was killed by §a" + killer.getName());
+            
+            // Set winner
+            winnerId = killerId;
+        } else {
+            // Environmental death
+            broadcastMessage("§c" + deadPlayer.getName() + " §7died");
+            
+            // Winner is the opponent
+            List<UUID> opponents = getOpponents(deadId);
+            if (!opponents.isEmpty()) {
+                winnerId = opponents.get(0);
+            }
+        }
+        
+        LOGGER.info("Player death in match " + matchId + ": " + deadPlayer.getName() +
+                   (killer != null ? " killed by " + killer.getName() : " (environmental)"));
+        
+        return true;
+    }
+    
+    @Override
+    public boolean handleObjective(String objectiveType, Player player, Map<String, Object> data) {
+        // PvP doesn't have objectives - deaths are the only win condition
+        return false;
+    }
+    
+    @Override
+    public boolean checkWinCondition() {
+        // Win condition: one team has no living players
+        // In 1v1 PvP, this means someone died
+        return winnerId != null;
+    }
+    
+    @Override
+    public Map<String, Object> getGameState() {
+        Map<String, Object> state = new HashMap<>();
+        state.put("gameType", gameType);
+        state.put("matchId", matchId);
+        state.put("state", this.state.name());
+        state.put("pvpEnabled", pvpEnabled);
+        state.put("durationMs", getDurationMillis());
+        
+        // Player stats
+        List<Map<String, Object>> playerStats = new ArrayList<>();
+        for (UUID playerId : players) {
+            Map<String, Object> stats = new HashMap<>();
+            stats.put("playerId", playerId.toString());
+            stats.put("team", getTeamForPlayer(playerId));
+            stats.put("kills", kills.getOrDefault(playerId, 0));
+            stats.put("deaths", deaths.getOrDefault(playerId, 0));
+            stats.put("damageDealt", damageDealt.getOrDefault(playerId, 0.0));
+            stats.put("disconnected", isPlayerDisconnected(playerId));
+            
+            // Online player info
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                stats.put("health", player.getHealth());
+                stats.put("hunger", player.getFoodLevel());
+            }
+            
+            playerStats.add(stats);
+        }
+        state.put("players", playerStats);
+        
+        // Winner info
+        if (winnerId != null) {
+            state.put("winnerId", winnerId.toString());
+        }
+        
+        return state;
+    }
+    
+    @Override
+    public void cleanup() {
+        // Cancel countdown if running
+        if (countdownTask != null && !countdownTask.isCancelled()) {
+            countdownTask.cancel();
+        }
+        
+        pvpEnabled = false;
+        
+        // Reset players (optional - they'll be teleported away anyway)
+        for (UUID playerId : players) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                // Clear any status effects
+                for (PotionEffect effect : player.getActivePotionEffects()) {
+                    player.removePotionEffect(effect.getType());
+                }
+            }
+        }
+        
+        LOGGER.info("PvP game cleanup completed for match " + matchId);
+    }
+    
+    // ==================== Disconnect Handling ====================
+    
+    @Override
+    public DisconnectResult handlePlayerDisconnect(UUID playerId, DisconnectReason reason) {
+        if (!hasPlayer(playerId)) {
+            return null;
+        }
+        
+        LOGGER.info("Player " + playerId + " disconnected from PvP match " + matchId + " (reason: " + reason + ")");
+        
+        // PvP uses instant forfeit - other team wins immediately
+        List<UUID> opponents = getOpponents(playerId);
+        if (!opponents.isEmpty()) {
+            winnerId = opponents.get(0);
+            
+            // Announce forfeit
+            broadcastMessage("§c" + getPlayerName(playerId) + " §7disconnected. §aOpponent wins!");
+        }
+        
+        // Mark as disconnected
+        disconnectedPlayers.put(playerId, System.currentTimeMillis());
+        
+        return DisconnectResult.FORFEIT;
+    }
+    
+    @Override
+    public boolean handlePlayerReconnect(UUID playerId) {
+        // PvP uses instant forfeit, so reconnect is not allowed
+        return false;
+    }
+    
+    @Override
+    public DisconnectPolicy getDisconnectPolicy() {
+        return DISCONNECT_POLICY;
+    }
+    
+    // ==================== Private Helper Methods ====================
+    
+    private void initPlayerStats(UUID playerId) {
+        kills.put(playerId, 0);
+        deaths.put(playerId, 0);
+        damageDealt.put(playerId, 0.0);
+    }
+    
+    private void teleportPlayersToSpawns(List<Player> blueTeamPlayers, List<Player> redTeamPlayers) {
+        // Get spawn points from arena config, or use defaults
+        List<SpawnPoint> blueSpawns = null;
+        List<SpawnPoint> redSpawns = null;
+        
+        if (arenaConfig != null) {
+            blueSpawns = arenaConfig.getSpawns("blue_team");
+            redSpawns = arenaConfig.getSpawns("red_team");
+        }
+        
+        // Teleport blue team
+        for (int i = 0; i < blueTeamPlayers.size(); i++) {
+            Player player = blueTeamPlayers.get(i);
+            Location spawnLoc;
+            
+            if (blueSpawns != null && i < blueSpawns.size()) {
+                spawnLoc = blueSpawns.get(i).toLocation(world);
+            } else {
+                // Default spawn
+                spawnLoc = new Location(world, 10, 65, 0, -90, 0);
+            }
+            
+            player.teleport(spawnLoc);
+        }
+        
+        // Teleport red team
+        for (int i = 0; i < redTeamPlayers.size(); i++) {
+            Player player = redTeamPlayers.get(i);
+            Location spawnLoc;
+            
+            if (redSpawns != null && i < redSpawns.size()) {
+                spawnLoc = redSpawns.get(i).toLocation(world);
+            } else {
+                // Default spawn
+                spawnLoc = new Location(world, -10, 65, 0, 90, 0);
+            }
+            
+            player.teleport(spawnLoc);
+        }
+    }
+    
+    private void setupPlayer(Player player) {
+        // Set game mode
+        player.setGameMode(GameMode.SURVIVAL);
+        
+        // Clear inventory
+        player.getInventory().clear();
+        
+        // Reset health and hunger
+        player.setHealth(20.0);
+        player.setFoodLevel(20);
+        player.setSaturation(20.0f);
+        
+        // Clear potion effects
+        for (PotionEffect effect : player.getActivePotionEffects()) {
+            player.removePotionEffect(effect.getType());
+        }
+        
+        // Give initial freeze effect during countdown
+        player.addPotionEffect(new PotionEffect(PotionEffectType.SLOWNESS, 
+                (COUNTDOWN_SECONDS + 1) * 20, 255, false, false));
+        player.addPotionEffect(new PotionEffect(PotionEffectType.JUMP_BOOST, 
+                (COUNTDOWN_SECONDS + 1) * 20, 128, false, false)); // Prevents jumping
+    }
+    
+    private void startCountdown() {
+        countdownTask = new BukkitRunnable() {
+            int countdown = COUNTDOWN_SECONDS;
+            
+            @Override
+            public void run() {
+                if (countdown > 0) {
+                    broadcastTitle("§e" + countdown, "§7Get ready to fight!");
+                    playSound(Sound.BLOCK_NOTE_BLOCK_PLING, 1.0f);
+                    countdown--;
+                } else {
+                    // Start the fight!
+                    startTime = System.currentTimeMillis();
+                    pvpEnabled = true;
+                    setState(GameState.IN_PROGRESS);
+                    
+                    broadcastTitle("§a§lFIGHT!", "");
+                    playSound(Sound.ENTITY_ENDER_DRAGON_GROWL, 1.0f);
+                    
+                    // Remove freeze effects
+                    for (UUID playerId : players) {
+                        Player player = Bukkit.getPlayer(playerId);
+                        if (player != null && player.isOnline()) {
+                            player.removePotionEffect(PotionEffectType.SLOWNESS);
+                            player.removePotionEffect(PotionEffectType.JUMP_BOOST);
+                        }
+                    }
+                    
+                    LOGGER.info("PvP match " + matchId + " started!");
+                    cancel();
+                }
+            }
+        }.runTaskTimer(plugin, 0L, 20L);
+    }
+    
+    private void broadcastMessage(String message) {
+        for (UUID playerId : players) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                player.sendMessage(message);
+            }
+        }
+    }
+    
+    private void broadcastTitle(String title, String subtitle) {
+        for (UUID playerId : players) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                player.sendTitle(title, subtitle, 5, 20, 5);
+            }
+        }
+    }
+    
+    private void playSound(Sound sound, float pitch) {
+        for (UUID playerId : players) {
+            Player player = Bukkit.getPlayer(playerId);
+            if (player != null && player.isOnline()) {
+                player.playSound(player.getLocation(), sound, 1.0f, pitch);
+            }
+        }
+    }
+    
+    private String getPlayerName(UUID playerId) {
+        Player player = Bukkit.getPlayer(playerId);
+        return player != null ? player.getName() : playerId.toString().substring(0, 8);
+    }
+    
+    // ==================== Public Methods ====================
+    
+    /**
+     * Check if PvP is currently enabled for this match.
+     */
+    public boolean isPvPEnabled() {
+        return pvpEnabled;
+    }
+    
+    /**
+     * Record damage dealt by a player.
+     * Call this from damage event listeners.
+     */
+    public void recordDamage(UUID attackerId, double damage) {
+        damageDealt.merge(attackerId, damage, Double::sum);
+    }
+    
+    /**
+     * Get kill count for a player.
+     */
+    public int getKills(UUID playerId) {
+        return kills.getOrDefault(playerId, 0);
+    }
+    
+    /**
+     * Get death count for a player.
+     */
+    public int getDeaths(UUID playerId) {
+        return deaths.getOrDefault(playerId, 0);
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchManager.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchManager.java
@@ -8,6 +8,9 @@ import org.bukkit.scheduler.BukkitRunnable;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import ai.blockwarriors.beacon.game.BaseGame;
+import ai.blockwarriors.beacon.game.DisconnectReason;
+import ai.blockwarriors.beacon.game.DisconnectResult;
 import ai.blockwarriors.beacon.util.ConvexClient;
 
 import java.util.*;
@@ -30,6 +33,9 @@ public class MatchManager {
     
     // Map player UUID to match ID
     private final Map<UUID, String> playerMatches = new HashMap<>();
+    
+    // Map match ID to BaseGame instance
+    private final Map<String, BaseGame> matchGames = new HashMap<>();
 
     public MatchManager(JavaPlugin plugin, String convexSiteUrl, String convexHttpSecret) {
         this.plugin = plugin;
@@ -41,9 +47,21 @@ public class MatchManager {
     }
 
     /**
-     * Register a match with its world and players
+     * Register a match with its world and players (legacy, no game instance).
      */
     public void registerMatch(String matchId, String worldName, List<Player> players) {
+        registerMatch(matchId, worldName, players, null);
+    }
+
+    /**
+     * Register a match with its world, players, and game instance.
+     * 
+     * @param matchId Unique match identifier
+     * @param worldName Name of the world for this match
+     * @param players List of players in the match
+     * @param game BaseGame instance (may be null for legacy matches)
+     */
+    public void registerMatch(String matchId, String worldName, List<Player> players, BaseGame game) {
         matchWorlds.put(matchId, worldName);
         
         Set<UUID> playerIds = new HashSet<>();
@@ -53,8 +71,15 @@ public class MatchManager {
         }
         matchPlayers.put(matchId, playerIds);
         
-        LOGGER.info("Registered match " + matchId + " with world " + worldName + 
-                   " and " + players.size() + " players");
+        // Store game instance if provided
+        if (game != null) {
+            matchGames.put(matchId, game);
+            LOGGER.info("Registered match " + matchId + " with game type " + game.getGameType() + 
+                       ", world " + worldName + " and " + players.size() + " players");
+        } else {
+            LOGGER.info("Registered match " + matchId + " (legacy) with world " + worldName + 
+                       " and " + players.size() + " players");
+        }
     }
 
     /**
@@ -79,11 +104,30 @@ public class MatchManager {
     }
 
     /**
-     * End a match - update status, delete world, kick players
+     * Get the game instance for a match.
+     * 
+     * @param matchId Match identifier
+     * @return BaseGame instance, or null if not found or legacy match
+     */
+    public BaseGame getGameForMatch(String matchId) {
+        return matchGames.get(matchId);
+    }
+
+    /**
+     * Check if a match has a game instance (non-legacy).
+     */
+    public boolean hasGame(String matchId) {
+        return matchGames.containsKey(matchId);
+    }
+
+    /**
+     * End a match - update status, delete world, kick players.
+     * Delegates cleanup to the game instance if available.
      */
     public void endMatch(String matchId, String winnerPlayerId) {
         String worldName = matchWorlds.get(matchId);
         Set<UUID> playerIds = matchPlayers.get(matchId);
+        BaseGame game = matchGames.get(matchId);
         
         if (worldName == null || playerIds == null) {
             LOGGER.warning("Cannot end match " + matchId + " - not found in registry");
@@ -91,6 +135,17 @@ public class MatchManager {
         }
 
         LOGGER.info("Ending match " + matchId + " (winner: " + (winnerPlayerId != null ? winnerPlayerId : "none") + ")");
+
+        // Call game cleanup if we have a game instance
+        if (game != null) {
+            try {
+                game.cleanup();
+                LOGGER.info("Game cleanup completed for match " + matchId);
+            } catch (Exception e) {
+                LOGGER.severe("Error during game cleanup for match " + matchId + ": " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
 
         // Capture and queue final telemetry NOW while player states are valid
         if (telemetryService != null) {
@@ -115,8 +170,8 @@ public class MatchManager {
                     }
                 }
 
-                // Delete the world
-                ai.blockwarriors.commands.debug.CreateMatchCommand.deleteMatchWorld(worldName);
+                // Delete the world using MatchPollingService's static method
+                MatchPollingService.deleteMatchWorld(worldName);
 
                 // Unregister players from telemetry service
                 if (telemetryService != null) {
@@ -128,6 +183,7 @@ public class MatchManager {
                 // Clean up registry
                 matchWorlds.remove(matchId);
                 matchPlayers.remove(matchId);
+                matchGames.remove(matchId);
                 for (UUID playerId : playerIds) {
                     playerMatches.remove(playerId);
                 }
@@ -165,6 +221,119 @@ public class MatchManager {
      */
     public boolean isPlayerInMatch(UUID playerId) {
         return playerMatches.containsKey(playerId);
+    }
+
+    // ==================== Event Delegation ====================
+
+    /**
+     * Delegate player death event to the game instance.
+     * 
+     * @param deadPlayer The player who died
+     * @param killer The killer (may be null)
+     * @return true if the game handled the event, false if legacy handling should be used
+     */
+    public boolean delegatePlayerDeath(Player deadPlayer, Player killer) {
+        String matchId = getMatchIdForPlayer(deadPlayer.getUniqueId());
+        if (matchId == null) {
+            return false;
+        }
+
+        BaseGame game = matchGames.get(matchId);
+        if (game == null || !game.isActive()) {
+            return false; // No game instance, use legacy handling
+        }
+
+        // Delegate to game
+        boolean handled = game.handlePlayerDeath(deadPlayer, killer);
+        
+        // Check win condition after death
+        if (handled && game.checkWinCondition()) {
+            UUID winnerId = game.getWinnerId();
+            endMatch(matchId, winnerId != null ? winnerId.toString() : null);
+        }
+
+        return handled;
+    }
+
+    /**
+     * Delegate player disconnect event to the game instance.
+     * 
+     * @param playerId UUID of the disconnecting player
+     * @param reason Reason for disconnect
+     * @return DisconnectResult indicating how the game handled it
+     */
+    public DisconnectResult delegatePlayerDisconnect(UUID playerId, DisconnectReason reason) {
+        String matchId = getMatchIdForPlayer(playerId);
+        if (matchId == null) {
+            return null;
+        }
+
+        BaseGame game = matchGames.get(matchId);
+        if (game == null || !game.isActive()) {
+            return null; // No game instance, return null for legacy handling
+        }
+
+        // Delegate to game
+        DisconnectResult result = game.handlePlayerDisconnect(playerId, reason);
+        
+        // Handle result
+        if (result == DisconnectResult.FORFEIT || result == DisconnectResult.GAME_CANCELLED) {
+            UUID winnerId = game.getWinnerId();
+            endMatch(matchId, winnerId != null ? winnerId.toString() : null);
+        }
+
+        return result;
+    }
+
+    /**
+     * Delegate player reconnect event to the game instance.
+     * 
+     * @param playerId UUID of the reconnecting player
+     * @return true if reconnect was handled by the game
+     */
+    public boolean delegatePlayerReconnect(UUID playerId) {
+        String matchId = getMatchIdForPlayer(playerId);
+        if (matchId == null) {
+            return false;
+        }
+
+        BaseGame game = matchGames.get(matchId);
+        if (game == null) {
+            return false;
+        }
+
+        return game.handlePlayerReconnect(playerId);
+    }
+
+    /**
+     * Delegate a game objective event to the game instance.
+     * 
+     * @param player Player who triggered the objective
+     * @param objectiveType Type of objective
+     * @param data Additional objective data
+     * @return true if objective was handled
+     */
+    public boolean delegateObjective(Player player, String objectiveType, Map<String, Object> data) {
+        String matchId = getMatchIdForPlayer(player.getUniqueId());
+        if (matchId == null) {
+            return false;
+        }
+
+        BaseGame game = matchGames.get(matchId);
+        if (game == null || !game.isActive()) {
+            return false;
+        }
+
+        // Delegate to game
+        boolean handled = game.handleObjective(objectiveType, player, data);
+        
+        // Check win condition after objective
+        if (handled && game.checkWinCondition()) {
+            UUID winnerId = game.getWinnerId();
+            endMatch(matchId, winnerId != null ? winnerId.toString() : null);
+        }
+
+        return handled;
     }
 }
 

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchManager.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchManager.java
@@ -9,8 +9,10 @@ import org.json.JSONArray;
 import org.json.JSONObject;
 
 import ai.blockwarriors.beacon.game.BaseGame;
+import ai.blockwarriors.beacon.game.DisconnectPolicy;
 import ai.blockwarriors.beacon.game.DisconnectReason;
 import ai.blockwarriors.beacon.game.DisconnectResult;
+import ai.blockwarriors.beacon.game.GracePeriodTracker;
 import ai.blockwarriors.beacon.util.ConvexClient;
 
 import java.util.*;
@@ -24,6 +26,7 @@ public class MatchManager {
     private final JavaPlugin plugin;
     private final ConvexClient convexClient;
     private MatchTelemetryService telemetryService;
+    private final GracePeriodTracker gracePeriodTracker;
     
     // Map match ID to world name
     private final Map<String, String> matchWorlds = new HashMap<>();
@@ -40,10 +43,18 @@ public class MatchManager {
     public MatchManager(JavaPlugin plugin, String convexSiteUrl, String convexHttpSecret) {
         this.plugin = plugin;
         this.convexClient = new ConvexClient(convexSiteUrl, convexHttpSecret);
+        this.gracePeriodTracker = new GracePeriodTracker(plugin);
     }
 
     public void setTelemetryService(MatchTelemetryService telemetryService) {
         this.telemetryService = telemetryService;
+    }
+    
+    /**
+     * Get the grace period tracker for disconnect handling.
+     */
+    public GracePeriodTracker getGracePeriodTracker() {
+        return gracePeriodTracker;
     }
 
     /**
@@ -135,6 +146,9 @@ public class MatchManager {
         }
 
         LOGGER.info("Ending match " + matchId + " (winner: " + (winnerPlayerId != null ? winnerPlayerId : "none") + ")");
+        
+        // Clear any active grace periods for this match
+        gracePeriodTracker.clearMatch(matchId);
 
         // Call game cleanup if we have a game instance
         if (game != null) {
@@ -276,13 +290,88 @@ public class MatchManager {
         // Delegate to game
         DisconnectResult result = game.handlePlayerDisconnect(playerId, reason);
         
-        // Handle result
-        if (result == DisconnectResult.FORFEIT || result == DisconnectResult.GAME_CANCELLED) {
-            UUID winnerId = game.getWinnerId();
-            endMatch(matchId, winnerId != null ? winnerId.toString() : null);
+        // Handle result based on game's decision
+        switch (result) {
+            case FORFEIT:
+            case GAME_CANCELLED:
+                // Game ended immediately
+                gracePeriodTracker.clearMatch(matchId);
+                UUID winnerId = game.getWinnerId();
+                endMatch(matchId, winnerId != null ? winnerId.toString() : null);
+                break;
+                
+            case GRACE_PERIOD:
+                // Start grace period tracking
+                DisconnectPolicy policy = game.getDisconnectPolicy();
+                gracePeriodTracker.startGracePeriod(
+                    playerId, 
+                    matchId, 
+                    policy.getGracePeriodSeconds(),
+                    reason,
+                    this::handleGracePeriodTimeout
+                );
+                
+                // Notify telemetry about the disconnect
+                if (telemetryService != null) {
+                    telemetryService.recordDisconnectEvent(matchId, playerId, reason, result, 
+                            policy.getGracePeriodSeconds());
+                }
+                break;
+                
+            case CONTINUE:
+                // Game continues, just record the disconnect
+                if (telemetryService != null) {
+                    telemetryService.recordDisconnectEvent(matchId, playerId, reason, result, 0);
+                }
+                break;
         }
 
         return result;
+    }
+    
+    /**
+     * Handle grace period timeout - player didn't reconnect in time.
+     * Called from GracePeriodTracker on the main thread.
+     */
+    private void handleGracePeriodTimeout(UUID playerId) {
+        String matchId = getMatchIdForPlayer(playerId);
+        if (matchId == null) {
+            LOGGER.warning("Grace period timeout for player not in match: " + playerId);
+            return;
+        }
+        
+        BaseGame game = matchGames.get(matchId);
+        if (game == null) {
+            LOGGER.warning("Grace period timeout but no game for match: " + matchId);
+            return;
+        }
+        
+        LOGGER.info("Grace period timeout for player " + playerId + " in match " + matchId);
+        
+        // Treat timeout as forfeit - get opponents as winners
+        List<UUID> opponents = game.getOpponents(playerId);
+        UUID winnerId = !opponents.isEmpty() ? opponents.get(0) : null;
+        
+        // Broadcast to remaining players
+        for (UUID pid : game.getPlayers()) {
+            if (!pid.equals(playerId)) {
+                Player p = Bukkit.getPlayer(pid);
+                if (p != null && p.isOnline()) {
+                    p.sendMessage("§a" + getPlayerName(playerId) + " did not reconnect in time. You win!");
+                }
+            }
+        }
+        
+        // End the match
+        endMatch(matchId, winnerId != null ? winnerId.toString() : null);
+    }
+    
+    /**
+     * Get player name by UUID, with fallback.
+     */
+    private String getPlayerName(UUID playerId) {
+        Player player = Bukkit.getPlayer(playerId);
+        return player != null ? player.getName() : playerId.toString().substring(0, 8);
     }
 
     /**
@@ -292,17 +381,55 @@ public class MatchManager {
      * @return true if reconnect was handled by the game
      */
     public boolean delegatePlayerReconnect(UUID playerId) {
-        String matchId = getMatchIdForPlayer(playerId);
-        if (matchId == null) {
+        // Check if player was in a grace period
+        if (!gracePeriodTracker.isInGracePeriod(playerId)) {
             return false;
         }
-
+        
+        GracePeriodTracker.DisconnectInfo info = gracePeriodTracker.getDisconnectInfo(playerId);
+        if (info == null) {
+            return false;
+        }
+        
+        String matchId = info.matchId;
         BaseGame game = matchGames.get(matchId);
         if (game == null) {
+            gracePeriodTracker.cancelGracePeriod(playerId);
             return false;
         }
 
-        return game.handlePlayerReconnect(playerId);
+        // Cancel the grace period timeout
+        gracePeriodTracker.cancelGracePeriod(playerId);
+        
+        // Delegate to game for reconnection handling
+        boolean handled = game.handlePlayerReconnect(playerId);
+        
+        if (handled) {
+            LOGGER.info("Player " + playerId + " successfully reconnected to match " + matchId);
+            
+            // Notify telemetry about the reconnect
+            if (telemetryService != null) {
+                telemetryService.recordReconnectEvent(matchId, playerId);
+            }
+        }
+        
+        return handled;
+    }
+    
+    /**
+     * Check if a player is in a grace period (disconnected but can reconnect).
+     */
+    public boolean isPlayerInGracePeriod(UUID playerId) {
+        return gracePeriodTracker.isInGracePeriod(playerId);
+    }
+    
+    /**
+     * Get the match ID for a player who is in a grace period.
+     * Returns null if player is not in a grace period.
+     */
+    public String getGracePeriodMatchId(UUID playerId) {
+        GracePeriodTracker.DisconnectInfo info = gracePeriodTracker.getDisconnectInfo(playerId);
+        return info != null ? info.matchId : null;
     }
 
     /**

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchPollingService.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchPollingService.java
@@ -1,16 +1,25 @@
 package ai.blockwarriors.beacon.service;
 
 import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.WorldType;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.json.JSONArray;
 import org.json.JSONObject;
 
+import ai.blockwarriors.beacon.arena.ArenaConfig;
+import ai.blockwarriors.beacon.arena.ArenaManager;
 import ai.blockwarriors.beacon.constants.GameConfig;
+import ai.blockwarriors.beacon.game.BaseGame;
+import ai.blockwarriors.beacon.game.GameRegistry;
 import ai.blockwarriors.beacon.util.ConvexClient;
 import ai.blockwarriors.beacon.util.ConvexResponseParser;
-import ai.blockwarriors.commands.debug.CreateMatchCommand;
 
+import java.io.File;
 import java.util.*;
 import java.util.logging.Logger;
 
@@ -31,6 +40,7 @@ public class MatchPollingService {
     private final JavaPlugin plugin;
     private final ConvexClient convexClient;
     private MatchManager matchManager;
+    private ArenaManager arenaManager;
     private int taskId = -1;
 
     /**
@@ -63,6 +73,10 @@ public class MatchPollingService {
 
     public void setMatchManager(MatchManager matchManager) {
         this.matchManager = matchManager;
+    }
+
+    public void setArenaManager(ArenaManager arenaManager) {
+        this.arenaManager = arenaManager;
     }
 
     public void start() {
@@ -368,43 +382,232 @@ public class MatchPollingService {
 
     /**
      * Create match world, teleport players, and register with managers.
+     * Uses GameRegistry to create game instances when available.
      * Must be called on the main thread (Bukkit API requirement).
      */
     private void createMatchWorld(String matchId, String matchType, List<Player> blueTeamPlayers,
             List<Player> redTeamPlayers) {
         try {
-            LOGGER.info("Creating match world for " + matchId + " with " +
+            LOGGER.info("Creating match world for " + matchId + " (type: " + matchType + ") with " +
                     blueTeamPlayers.size() + " blue players and " +
                     redTeamPlayers.size() + " red players");
 
-            // For now, support 1v1 matches (can be extended later)
-            if (blueTeamPlayers.size() == 1 && redTeamPlayers.size() == 1) {
-                Player bluePlayer = blueTeamPlayers.get(0);
-                Player redPlayer = redTeamPlayers.get(0);
-
-                String worldName = CreateMatchCommand.createMatch(bluePlayer, redPlayer);
-                if (worldName == null) {
-                    LOGGER.severe("Failed to create match world for match " + matchId);
-                    return;
-                }
-
-                LOGGER.info("Match created between " + bluePlayer.getName() + " and " + redPlayer.getName());
-
-                // Register with match manager
-                if (matchManager != null) {
-                    matchManager.registerMatch(matchId, worldName, Arrays.asList(bluePlayer, redPlayer));
-                }
-
-                // Register for telemetry
-                registerPlayersForTelemetry(matchId, bluePlayer, redPlayer);
-            } else {
-                LOGGER.warning("Match type " + matchType + " with " +
-                        blueTeamPlayers.size() + " vs " + redTeamPlayers.size() +
-                        " players not yet supported. Only 1v1 is supported.");
+            // Create the world first
+            String worldName = createWorld(matchId);
+            if (worldName == null) {
+                LOGGER.severe("Failed to create match world for match " + matchId);
+                return;
             }
+
+            World world = Bukkit.getWorld(worldName);
+            if (world == null) {
+                LOGGER.severe("World " + worldName + " not found after creation");
+                return;
+            }
+
+            // Check if game type is registered in GameRegistry
+            GameRegistry registry = GameRegistry.getInstance();
+            if (registry.isRegistered(matchType)) {
+                // Use GameRegistry to create and initialize the game
+                createGameViaRegistry(matchId, matchType, world, worldName, blueTeamPlayers, redTeamPlayers);
+            } else {
+                // Legacy fallback for unregistered game types
+                LOGGER.info("Game type '" + matchType + "' not registered, using legacy initialization");
+                createLegacyMatch(matchId, world, worldName, blueTeamPlayers, redTeamPlayers);
+            }
+
         } catch (Exception e) {
             LOGGER.severe("Error creating match world: " + e.getMessage());
             e.printStackTrace();
+        }
+    }
+
+    /**
+     * Create a new match world.
+     * 
+     * @param matchId Match identifier (used for logging)
+     * @return World name, or null if creation failed
+     */
+    private String createWorld(String matchId) {
+        // Find the lowest unused world number
+        int worldNumber = 1;
+        String worldName = "match_" + worldNumber;
+        while (Bukkit.getWorld(worldName) != null) {
+            worldNumber++;
+            worldName = "match_" + worldNumber;
+        }
+
+        try {
+            WorldCreator creator = new WorldCreator(worldName);
+            creator.type(WorldType.FLAT);
+            creator.generateStructures(false);
+
+            World world = creator.createWorld();
+            if (world == null) {
+                LOGGER.severe("Failed to create world: " + worldName);
+                return null;
+            }
+
+            // Configure world settings
+            world.setSpawnLocation(0, 64, 0);
+            world.setSpawnFlags(false, false); // No monsters, no animals
+            world.setDifficulty(org.bukkit.Difficulty.PEACEFUL);
+
+            LOGGER.info("Created world " + worldName + " for match " + matchId);
+            return worldName;
+
+        } catch (Exception e) {
+            LOGGER.severe("Error creating world: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
+
+    /**
+     * Create and initialize a game using GameRegistry.
+     * The game handles player setup via its initialize() and start() methods.
+     */
+    private void createGameViaRegistry(String matchId, String matchType, World world, String worldName,
+            List<Player> blueTeamPlayers, List<Player> redTeamPlayers) {
+        
+        GameRegistry registry = GameRegistry.getInstance();
+        
+        // Create game instance via registry
+        BaseGame game = registry.createGame(matchType, plugin, matchId);
+        if (game == null) {
+            LOGGER.severe("Failed to create game instance for type: " + matchType);
+            // Fall back to legacy behavior
+            createLegacyMatch(matchId, world, worldName, blueTeamPlayers, redTeamPlayers);
+            return;
+        }
+
+        // Get arena configuration for this game type
+        ArenaConfig arenaConfig = null;
+        if (arenaManager != null) {
+            arenaConfig = arenaManager.getDefaultArena(matchType);
+            if (arenaConfig == null) {
+                LOGGER.warning("No arena config found for game type: " + matchType + ", using null config");
+            }
+        }
+
+        // Initialize the game with world, arena config, and players
+        game.initialize(world, arenaConfig, blueTeamPlayers, redTeamPlayers);
+
+        // Collect all players
+        List<Player> allPlayers = new ArrayList<>();
+        allPlayers.addAll(blueTeamPlayers);
+        allPlayers.addAll(redTeamPlayers);
+
+        // Register with match manager (now includes the game instance)
+        if (matchManager != null) {
+            matchManager.registerMatch(matchId, worldName, allPlayers, game);
+        }
+
+        // Register for telemetry
+        registerPlayersForTelemetry(matchId, allPlayers.toArray(new Player[0]));
+
+        // Start the game
+        game.start();
+
+        LOGGER.info("Game " + matchType + " started for match " + matchId + " via GameRegistry");
+    }
+
+    /**
+     * Legacy match creation for backward compatibility.
+     * Used when game type is not registered in GameRegistry.
+     */
+    private void createLegacyMatch(String matchId, World world, String worldName,
+            List<Player> blueTeamPlayers, List<Player> redTeamPlayers) {
+        
+        // For now, support 1v1 matches in legacy mode
+        if (blueTeamPlayers.size() == 1 && redTeamPlayers.size() == 1) {
+            Player bluePlayer = blueTeamPlayers.get(0);
+            Player redPlayer = redTeamPlayers.get(0);
+
+            // Set both players to survival mode
+            bluePlayer.setGameMode(GameMode.SURVIVAL);
+            redPlayer.setGameMode(GameMode.SURVIVAL);
+
+            // Teleport players to spawn positions
+            Location blueLoc = new Location(world, 5, -61, 0);
+            Location redLoc = new Location(world, -5, -61, 0);
+            bluePlayer.teleport(blueLoc);
+            redPlayer.teleport(redLoc);
+
+            // Clear inventories and reset health/hunger for fair start
+            bluePlayer.getInventory().clear();
+            redPlayer.getInventory().clear();
+            bluePlayer.setHealth(20.0);
+            redPlayer.setHealth(20.0);
+            bluePlayer.setFoodLevel(20);
+            redPlayer.setFoodLevel(20);
+            bluePlayer.setSaturation(20.0f);
+            redPlayer.setSaturation(20.0f);
+
+            LOGGER.info("Legacy match created between " + bluePlayer.getName() + " and " + redPlayer.getName());
+
+            // Register with match manager (without game instance for legacy)
+            if (matchManager != null) {
+                matchManager.registerMatch(matchId, worldName, Arrays.asList(bluePlayer, redPlayer));
+            }
+
+            // Register for telemetry
+            registerPlayersForTelemetry(matchId, bluePlayer, redPlayer);
+        } else {
+            LOGGER.warning("Legacy mode only supports 1v1 matches. Got " +
+                    blueTeamPlayers.size() + " vs " + redTeamPlayers.size() + " players.");
+        }
+    }
+
+    /**
+     * Delete a match world and unload it from memory.
+     */
+    public static void deleteMatchWorld(String worldName) {
+        try {
+            World world = Bukkit.getWorld(worldName);
+            if (world != null) {
+                // Kick all players from the world first
+                world.getPlayers().forEach(player -> {
+                    World mainWorld = Bukkit.getWorlds().get(0);
+                    if (mainWorld != null && !mainWorld.equals(world)) {
+                        player.teleport(mainWorld.getSpawnLocation());
+                    } else {
+                        player.kickPlayer("Match ended. World is being deleted.");
+                    }
+                });
+
+                // Unload the world
+                Bukkit.unloadWorld(world, false);
+
+                // Delete the world folder
+                File worldFolder = world.getWorldFolder();
+                if (worldFolder.exists()) {
+                    deleteDirectory(worldFolder);
+                    LOGGER.info("Deleted match world: " + worldName);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.severe("Error deleting match world " + worldName + ": " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Recursively delete a directory.
+     */
+    private static void deleteDirectory(File directory) {
+        if (directory.exists()) {
+            File[] files = directory.listFiles();
+            if (files != null) {
+                for (File file : files) {
+                    if (file.isDirectory()) {
+                        deleteDirectory(file);
+                    } else {
+                        file.delete();
+                    }
+                }
+            }
+            directory.delete();
         }
     }
 

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchTelemetryService.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchTelemetryService.java
@@ -11,10 +11,14 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import ai.blockwarriors.beacon.game.BaseGame;
+import ai.blockwarriors.beacon.game.DisconnectReason;
+import ai.blockwarriors.beacon.game.DisconnectResult;
 import ai.blockwarriors.beacon.util.ConvexClient;
 import ai.blockwarriors.beacon.util.ConvexResponseParser;
 
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 /**
@@ -23,16 +27,63 @@ import java.util.logging.Logger;
  * API calls accept arrays to minimize Convex usage:
  * - Fetch match statuses for all active matches
  * - Update match states
+ * 
+ * Telemetry includes:
+ * - Base player stats (health, position, equipment)
+ * - Game-specific state from BaseGame.getGameState()
+ * - Disconnect/reconnect events
  */
 public class MatchTelemetryService {
     private static final Logger LOGGER = Logger.getLogger("beacon");
     private static final long UPDATE_INTERVAL_TICKS = 20L; // Update every second (20 ticks)
 
     /**
+     * Represents a disconnect or reconnect event for telemetry.
+     */
+    public static class DisconnectEvent {
+        public final String type; // "disconnect" or "reconnect"
+        public final UUID playerId;
+        public final long timestamp;
+        public final DisconnectReason reason; // null for reconnects
+        public final DisconnectResult result; // null for reconnects
+        public final int gracePeriodSeconds; // 0 for instant forfeit or reconnect
+        
+        public DisconnectEvent(String type, UUID playerId, DisconnectReason reason, 
+                              DisconnectResult result, int gracePeriodSeconds) {
+            this.type = type;
+            this.playerId = playerId;
+            this.timestamp = System.currentTimeMillis();
+            this.reason = reason;
+            this.result = result;
+            this.gracePeriodSeconds = gracePeriodSeconds;
+        }
+        
+        public JSONObject toJSON() {
+            JSONObject json = new JSONObject();
+            json.put("type", type);
+            json.put("playerId", playerId.toString());
+            json.put("timestamp", timestamp);
+            if (reason != null) {
+                json.put("reason", reason.name());
+            }
+            if (result != null) {
+                json.put("result", result.name());
+            }
+            if (gracePeriodSeconds > 0) {
+                json.put("gracePeriodSeconds", gracePeriodSeconds);
+                json.put("gracePeriodEnds", timestamp + (gracePeriodSeconds * 1000L));
+            }
+            return json;
+        }
+    }
+
+    /**
      * Per-match tracking state.
      */
     private static class MatchState {
         final Set<UUID> playerIds = new HashSet<>();
+        final List<DisconnectEvent> events = new ArrayList<>();
+        final Set<UUID> disconnectedPlayers = ConcurrentHashMap.newKeySet();
         JSONObject finalTelemetry; // captured at moment of match end, sent on next update
     }
 
@@ -40,11 +91,19 @@ public class MatchTelemetryService {
     private final ConvexClient convexClient;
     private final Map<String, MatchState> matches = new HashMap<>();
     private final Map<UUID, String> playerToMatch = new HashMap<>(); // reverse lookup
+    private MatchManager matchManager; // For accessing game instances
     private int taskId = -1;
 
     public MatchTelemetryService(JavaPlugin plugin, String convexSiteUrl, String convexHttpSecret) {
         this.plugin = plugin;
         this.convexClient = new ConvexClient(convexSiteUrl, convexHttpSecret);
+    }
+    
+    /**
+     * Set the MatchManager reference for accessing game instances.
+     */
+    public void setMatchManager(MatchManager matchManager) {
+        this.matchManager = matchManager;
     }
 
     // ==================== Lifecycle ====================
@@ -113,6 +172,53 @@ public class MatchTelemetryService {
      */
     public boolean isPlayerInMatch(UUID playerId) {
         return playerToMatch.containsKey(playerId);
+    }
+    
+    // ==================== Disconnect/Reconnect Events ====================
+    
+    /**
+     * Record a player disconnect event.
+     * 
+     * @param matchId Match the player disconnected from
+     * @param playerId UUID of the disconnected player
+     * @param reason Why the player disconnected
+     * @param result How the game handled the disconnect
+     * @param gracePeriodSeconds Grace period (0 for instant forfeit)
+     */
+    public void recordDisconnectEvent(String matchId, UUID playerId, DisconnectReason reason,
+                                      DisconnectResult result, int gracePeriodSeconds) {
+        MatchState state = matches.get(matchId);
+        if (state == null) {
+            LOGGER.warning("Cannot record disconnect for match " + matchId + " - not tracked");
+            return;
+        }
+        
+        DisconnectEvent event = new DisconnectEvent("disconnect", playerId, reason, result, gracePeriodSeconds);
+        state.events.add(event);
+        state.disconnectedPlayers.add(playerId);
+        
+        LOGGER.info("Recorded disconnect event for player " + playerId + " in match " + matchId + 
+                   " (result: " + result + ")");
+    }
+    
+    /**
+     * Record a player reconnect event.
+     * 
+     * @param matchId Match the player reconnected to
+     * @param playerId UUID of the reconnected player
+     */
+    public void recordReconnectEvent(String matchId, UUID playerId) {
+        MatchState state = matches.get(matchId);
+        if (state == null) {
+            LOGGER.warning("Cannot record reconnect for match " + matchId + " - not tracked");
+            return;
+        }
+        
+        DisconnectEvent event = new DisconnectEvent("reconnect", playerId, null, null, 0);
+        state.events.add(event);
+        state.disconnectedPlayers.remove(playerId);
+        
+        LOGGER.info("Recorded reconnect event for player " + playerId + " in match " + matchId);
     }
 
     // ==================== Main Update Loop ====================
@@ -217,7 +323,8 @@ public class MatchTelemetryService {
         }
 
         // Capture telemetry NOW - during death event, dead player's health is still 0
-        JSONObject telemetry = collectMatchTelemetry(matchId, state.playerIds);
+        // Pass the state explicitly to ensure events are included
+        JSONObject telemetry = collectMatchTelemetry(matchId, state.playerIds, state);
         
         // Log captured health values for verification
         JSONArray players = telemetry.optJSONArray("players");
@@ -238,6 +345,9 @@ public class MatchTelemetryService {
         telemetry.put("matchEnded", true);
         telemetry.put("finalState", true);
         
+        // Include total events count
+        telemetry.put("totalEvents", state.events.size());
+        
         state.finalTelemetry = telemetry;
     }
 
@@ -245,24 +355,87 @@ public class MatchTelemetryService {
 
     /**
      * Collect telemetry data for all players in a match.
+     * Merges base telemetry with game-specific state from BaseGame.getGameState().
      */
     private JSONObject collectMatchTelemetry(String matchId, Set<UUID> playerIds) {
+        MatchState matchState = matches.get(matchId);
+        return collectMatchTelemetry(matchId, playerIds, matchState);
+    }
+    
+    /**
+     * Collect telemetry data for all players in a match with explicit MatchState.
+     */
+    private JSONObject collectMatchTelemetry(String matchId, Set<UUID> playerIds, MatchState matchState) {
         try {
-            JSONObject matchState = new JSONObject();
-            matchState.put("timestamp", System.currentTimeMillis());
-            matchState.put("matchId", matchId);
+            JSONObject telemetry = new JSONObject();
+            telemetry.put("timestamp", System.currentTimeMillis());
+            telemetry.put("matchId", matchId);
 
+            // Collect base player telemetry
             JSONArray players = new JSONArray();
-
             for (UUID playerId : playerIds) {
                 Player player = Bukkit.getPlayer(playerId);
                 if (player != null && player.isOnline()) {
-                    players.put(collectPlayerTelemetry(player));
+                    JSONObject playerData = collectPlayerTelemetry(player);
+                    // Mark if player was recently disconnected
+                    if (matchState != null && matchState.disconnectedPlayers.contains(playerId)) {
+                        playerData.put("recentlyDisconnected", true);
+                    }
+                    players.put(playerData);
+                } else if (matchState != null && matchState.disconnectedPlayers.contains(playerId)) {
+                    // Include disconnected player with minimal data
+                    JSONObject disconnectedPlayer = new JSONObject();
+                    disconnectedPlayer.put("playerId", playerId.toString());
+                    disconnectedPlayer.put("disconnected", true);
+                    players.put(disconnectedPlayer);
+                }
+            }
+            telemetry.put("players", players);
+            
+            // Include disconnect/reconnect events
+            if (matchState != null && !matchState.events.isEmpty()) {
+                JSONArray events = new JSONArray();
+                for (DisconnectEvent event : matchState.events) {
+                    events.put(event.toJSON());
+                }
+                telemetry.put("events", events);
+                
+                // Include list of currently disconnected players
+                JSONArray disconnectedList = new JSONArray();
+                for (UUID pid : matchState.disconnectedPlayers) {
+                    disconnectedList.put(pid.toString());
+                }
+                telemetry.put("disconnectedPlayers", disconnectedList);
+            }
+            
+            // Merge game-specific state from BaseGame
+            if (matchManager != null) {
+                BaseGame game = matchManager.getGameForMatch(matchId);
+                if (game != null) {
+                    try {
+                        Map<String, Object> gameState = game.getGameState();
+                        if (gameState != null && !gameState.isEmpty()) {
+                            JSONObject gameSpecific = new JSONObject(gameState);
+                            telemetry.put("gameSpecific", gameSpecific);
+                            
+                            // Also copy some key fields to top level for convenience
+                            if (gameState.containsKey("gameType")) {
+                                telemetry.put("gameType", gameState.get("gameType"));
+                            }
+                            if (gameState.containsKey("state")) {
+                                telemetry.put("gameState", gameState.get("state"));
+                            }
+                            if (gameState.containsKey("winnerId")) {
+                                telemetry.put("winnerId", gameState.get("winnerId"));
+                            }
+                        }
+                    } catch (Exception e) {
+                        LOGGER.warning("Error getting game state for telemetry: " + e.getMessage());
+                    }
                 }
             }
 
-            matchState.put("players", players);
-            return matchState;
+            return telemetry;
         } catch (JSONException e) {
             LOGGER.severe("Error collecting match telemetry: " + e.getMessage());
             e.printStackTrace();

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/EndGameCommand.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/EndGameCommand.java
@@ -1,0 +1,137 @@
+package ai.blockwarriors.commands.debug;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import ai.blockwarriors.beacon.Plugin;
+import ai.blockwarriors.beacon.game.BaseGame;
+import ai.blockwarriors.beacon.service.MatchManager;
+
+/**
+ * Debug command to force end a game.
+ * 
+ * Usage:
+ *   /endgame              - End current game with no winner
+ *   /endgame <winner>     - End current game with specified winner
+ *   /endgame blue         - End game with blue team winning
+ *   /endgame red          - End game with red team winning
+ */
+public class EndGameCommand implements CommandExecutor, TabCompleter {
+    
+    private static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    private final Plugin plugin;
+    
+    public EndGameCommand(Plugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cThis command can only be used by players.");
+            return true;
+        }
+        
+        Player player = (Player) sender;
+        MatchManager matchManager = plugin.getMatchManager();
+        
+        if (matchManager == null) {
+            player.sendMessage("§cMatchManager not initialized.");
+            return true;
+        }
+        
+        // Find match for this player
+        String matchId = matchManager.getMatchIdForPlayer(player.getUniqueId());
+        if (matchId == null) {
+            player.sendMessage("§cYou are not in an active match.");
+            return true;
+        }
+        
+        BaseGame game = matchManager.getGameForMatch(matchId);
+        String winnerPlayerId = null;
+        
+        if (args.length > 0) {
+            String winnerArg = args[0].toLowerCase();
+            
+            if (winnerArg.equals("blue") && game != null) {
+                // Get first blue team player
+                List<UUID> blueTeam = game.getBlueTeam();
+                if (!blueTeam.isEmpty()) {
+                    winnerPlayerId = blueTeam.get(0).toString();
+                    player.sendMessage("§aEnding game with §bblue team §aas winner.");
+                }
+            } else if (winnerArg.equals("red") && game != null) {
+                // Get first red team player
+                List<UUID> redTeam = game.getRedTeam();
+                if (!redTeam.isEmpty()) {
+                    winnerPlayerId = redTeam.get(0).toString();
+                    player.sendMessage("§aEnding game with §cred team §aas winner.");
+                }
+            } else if (winnerArg.equals("none") || winnerArg.equals("draw")) {
+                winnerPlayerId = null;
+                player.sendMessage("§aEnding game with no winner (draw).");
+            } else {
+                // Try to find player by name
+                Player winner = Bukkit.getPlayer(args[0]);
+                if (winner != null && winner.isOnline()) {
+                    winnerPlayerId = winner.getUniqueId().toString();
+                    player.sendMessage("§aEnding game with §e" + winner.getName() + " §aas winner.");
+                } else {
+                    player.sendMessage("§cPlayer not found: §e" + args[0]);
+                    player.sendMessage("§7Use: §e/endgame [blue|red|none|<player>]");
+                    return true;
+                }
+            }
+        } else {
+            player.sendMessage("§aEnding game with no winner.");
+        }
+        
+        // End the match
+        LOGGER.info("Force ending match " + matchId + " by command from " + player.getName());
+        matchManager.endMatch(matchId, winnerPlayerId);
+        
+        return true;
+    }
+    
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        List<String> completions = new ArrayList<>();
+        
+        if (args.length == 1) {
+            String partial = args[0].toLowerCase();
+            
+            // Add team options
+            if ("blue".startsWith(partial)) {
+                completions.add("blue");
+            }
+            if ("red".startsWith(partial)) {
+                completions.add("red");
+            }
+            if ("none".startsWith(partial)) {
+                completions.add("none");
+            }
+            if ("draw".startsWith(partial)) {
+                completions.add("draw");
+            }
+            
+            // Add online player names
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getName().toLowerCase().startsWith(partial)) {
+                    completions.add(p.getName());
+                }
+            }
+        }
+        
+        return completions;
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/SetArenaCommand.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/SetArenaCommand.java
@@ -1,0 +1,176 @@
+package ai.blockwarriors.commands.debug;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import ai.blockwarriors.beacon.Plugin;
+import ai.blockwarriors.beacon.arena.ArenaConfig;
+import ai.blockwarriors.beacon.arena.ArenaManager;
+
+/**
+ * Debug command to load an arena for testing.
+ * 
+ * Usage:
+ *   /setarena <arena_name> - Load and display arena info
+ *   /setarena list         - List all available arenas
+ *   /setarena reload       - Reload arena configurations
+ */
+public class SetArenaCommand implements CommandExecutor, TabCompleter {
+    
+    private static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    private final Plugin plugin;
+    
+    public SetArenaCommand(Plugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cThis command can only be used by players.");
+            return true;
+        }
+        
+        Player player = (Player) sender;
+        ArenaManager arenaManager = plugin.getArenaManager();
+        
+        if (arenaManager == null) {
+            player.sendMessage("§cArenaManager not initialized.");
+            return true;
+        }
+        
+        if (args.length == 0) {
+            sendUsage(player);
+            return true;
+        }
+        
+        String subCommand = args[0].toLowerCase();
+        
+        switch (subCommand) {
+            case "list":
+                listArenas(player, arenaManager);
+                break;
+            case "reload":
+                reloadArenas(player, arenaManager);
+                break;
+            default:
+                showArenaInfo(player, arenaManager, subCommand);
+                break;
+        }
+        
+        return true;
+    }
+    
+    private void sendUsage(Player player) {
+        player.sendMessage("§6=== Set Arena Command ===");
+        player.sendMessage("§e/setarena <arena_name> §7- Show arena info");
+        player.sendMessage("§e/setarena list §7- List all arenas");
+        player.sendMessage("§e/setarena reload §7- Reload arena configs");
+    }
+    
+    private void listArenas(Player player, ArenaManager arenaManager) {
+        player.sendMessage("§6=== Available Arenas ===");
+        
+        int count = arenaManager.getArenaCount();
+        if (count == 0) {
+            player.sendMessage("§7No arenas loaded.");
+            player.sendMessage("§7Place arena configs in §eplugins/beacon/arenas/");
+            return;
+        }
+        
+        for (String arenaName : arenaManager.getArenaNames()) {
+            ArenaConfig config = arenaManager.getArena(arenaName);
+            if (config != null) {
+                String gameType = config.getGameType();
+                player.sendMessage("§a  - " + arenaName + " §7[" + gameType + "]");
+            }
+        }
+        
+        player.sendMessage("§7Total: §f" + count + " §7arenas");
+    }
+    
+    private void reloadArenas(Player player, ArenaManager arenaManager) {
+        player.sendMessage("§eReloading arena configurations...");
+        
+        int before = arenaManager.getArenaCount();
+        arenaManager.loadArenas();
+        int after = arenaManager.getArenaCount();
+        
+        player.sendMessage("§aReloaded! §7Arenas: " + before + " -> " + after);
+        LOGGER.info("Arena configs reloaded by " + player.getName());
+    }
+    
+    private void showArenaInfo(Player player, ArenaManager arenaManager, String arenaName) {
+        ArenaConfig config = arenaManager.getArena(arenaName);
+        
+        if (config == null) {
+            player.sendMessage("§cArena not found: §e" + arenaName);
+            player.sendMessage("§7Use §e/setarena list §7to see available arenas.");
+            return;
+        }
+        
+        player.sendMessage("§6=== Arena: " + config.getName() + " ===");
+        player.sendMessage("§7Game Type: §f" + config.getGameType());
+        
+        if (config.hasSchematic()) {
+            player.sendMessage("§7Schematic: §f" + config.getSchematicPath());
+        }
+        
+        // Show spawn counts
+        int blueSpawns = config.getSpawns("blue_team").size();
+        int redSpawns = config.getSpawns("red_team").size();
+        player.sendMessage("§7Spawns: §bBlue=" + blueSpawns + " §cRed=" + redSpawns);
+        
+        // Show boundaries
+        if (config.hasBoundaries()) {
+            player.sendMessage("§7Boundaries: §fdefined");
+        }
+        
+        // Show objectives
+        int objectiveCount = config.getObjectives().size();
+        if (objectiveCount > 0) {
+            player.sendMessage("§7Objectives: §f" + objectiveCount);
+        }
+        
+        // Show resources
+        int resourceCount = config.getResources().size();
+        if (resourceCount > 0) {
+            player.sendMessage("§7Resource spawns: §f" + resourceCount);
+        }
+    }
+    
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        List<String> completions = new ArrayList<>();
+        
+        if (args.length == 1) {
+            String partial = args[0].toLowerCase();
+            
+            if ("list".startsWith(partial)) {
+                completions.add("list");
+            }
+            if ("reload".startsWith(partial)) {
+                completions.add("reload");
+            }
+            
+            ArenaManager arenaManager = plugin.getArenaManager();
+            if (arenaManager != null) {
+                for (String arenaName : arenaManager.getArenaNames()) {
+                    if (arenaName.toLowerCase().startsWith(partial)) {
+                        completions.add(arenaName);
+                    }
+                }
+            }
+        }
+        
+        return completions;
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/SimulateDisconnectCommand.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/SimulateDisconnectCommand.java
@@ -1,0 +1,156 @@
+package ai.blockwarriors.commands.debug;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import ai.blockwarriors.beacon.Plugin;
+import ai.blockwarriors.beacon.game.BaseGame;
+import ai.blockwarriors.beacon.game.DisconnectReason;
+import ai.blockwarriors.beacon.game.DisconnectResult;
+import ai.blockwarriors.beacon.service.MatchManager;
+
+/**
+ * Debug command to simulate player disconnect without actual disconnect.
+ * 
+ * Usage:
+ *   /simulatedisconnect <player>           - Simulate quit disconnect
+ *   /simulatedisconnect <player> <reason>  - Simulate with specific reason
+ *   
+ * Reasons: quit, kick, timeout
+ */
+public class SimulateDisconnectCommand implements CommandExecutor, TabCompleter {
+    
+    private static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    private final Plugin plugin;
+    
+    public SimulateDisconnectCommand(Plugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cThis command can only be used by players.");
+            return true;
+        }
+        
+        Player player = (Player) sender;
+        MatchManager matchManager = plugin.getMatchManager();
+        
+        if (matchManager == null) {
+            player.sendMessage("§cMatchManager not initialized.");
+            return true;
+        }
+        
+        if (args.length == 0) {
+            sendUsage(player);
+            return true;
+        }
+        
+        // Find target player
+        Player targetPlayer = Bukkit.getPlayer(args[0]);
+        if (targetPlayer == null || !targetPlayer.isOnline()) {
+            player.sendMessage("§cPlayer not found: §e" + args[0]);
+            return true;
+        }
+        
+        // Check if player is in a match
+        String matchId = matchManager.getMatchIdForPlayer(targetPlayer.getUniqueId());
+        if (matchId == null) {
+            player.sendMessage("§c" + targetPlayer.getName() + " is not in an active match.");
+            return true;
+        }
+        
+        BaseGame game = matchManager.getGameForMatch(matchId);
+        if (game == null) {
+            player.sendMessage("§cNo game instance found (legacy match?).");
+            return true;
+        }
+        
+        // Parse disconnect reason
+        DisconnectReason reason = DisconnectReason.QUIT;
+        if (args.length >= 2) {
+            String reasonArg = args[1].toUpperCase();
+            try {
+                reason = DisconnectReason.valueOf(reasonArg);
+            } catch (IllegalArgumentException e) {
+                player.sendMessage("§cInvalid reason: §e" + args[1]);
+                player.sendMessage("§7Valid reasons: quit, kick, timeout");
+                return true;
+            }
+        }
+        
+        player.sendMessage("§eSimulating disconnect for §f" + targetPlayer.getName() + " §e(reason: " + reason + ")");
+        
+        // Delegate to match manager
+        DisconnectResult result = matchManager.delegatePlayerDisconnect(targetPlayer.getUniqueId(), reason);
+        
+        if (result == null) {
+            player.sendMessage("§cDisconnect not handled (legacy match or game not active).");
+            return true;
+        }
+        
+        // Report result
+        switch (result) {
+            case FORFEIT:
+                player.sendMessage("§cResult: §fFORFEIT §7- Other team wins");
+                break;
+            case GRACE_PERIOD:
+                player.sendMessage("§eResult: §fGRACE_PERIOD §7- Waiting for reconnect");
+                int gracePeriod = game.getDisconnectPolicy().getGracePeriodSeconds();
+                player.sendMessage("§7Grace period: §f" + gracePeriod + " seconds");
+                break;
+            case CONTINUE:
+                player.sendMessage("§aResult: §fCONTINUE §7- Game continues with remaining players");
+                break;
+            case GAME_CANCELLED:
+                player.sendMessage("§cResult: §fGAME_CANCELLED §7- Not enough players");
+                break;
+        }
+        
+        LOGGER.info("Simulated disconnect for " + targetPlayer.getName() + ": " + reason + " -> " + result);
+        
+        return true;
+    }
+    
+    private void sendUsage(Player player) {
+        player.sendMessage("§6=== Simulate Disconnect Command ===");
+        player.sendMessage("§e/simulatedisconnect <player> §7- Simulate quit");
+        player.sendMessage("§e/simulatedisconnect <player> <reason> §7- With reason");
+        player.sendMessage("§7Reasons: §fquit§7, §fkick§7, §ftimeout");
+    }
+    
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        List<String> completions = new ArrayList<>();
+        
+        if (args.length == 1) {
+            // Player names
+            String partial = args[0].toLowerCase();
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getName().toLowerCase().startsWith(partial)) {
+                    completions.add(p.getName());
+                }
+            }
+        } else if (args.length == 2) {
+            // Disconnect reasons
+            String partial = args[1].toLowerCase();
+            for (DisconnectReason reason : DisconnectReason.values()) {
+                if (reason.name().toLowerCase().startsWith(partial)) {
+                    completions.add(reason.name().toLowerCase());
+                }
+            }
+        }
+        
+        return completions;
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/SimulateReconnectCommand.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/SimulateReconnectCommand.java
@@ -1,0 +1,119 @@
+package ai.blockwarriors.commands.debug;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import ai.blockwarriors.beacon.Plugin;
+import ai.blockwarriors.beacon.game.BaseGame;
+import ai.blockwarriors.beacon.service.MatchManager;
+
+/**
+ * Debug command to simulate player reconnect during grace period.
+ * 
+ * Usage:
+ *   /simulatereconnect <player> - Simulate player reconnecting
+ */
+public class SimulateReconnectCommand implements CommandExecutor, TabCompleter {
+    
+    private static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    private final Plugin plugin;
+    
+    public SimulateReconnectCommand(Plugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cThis command can only be used by players.");
+            return true;
+        }
+        
+        Player player = (Player) sender;
+        MatchManager matchManager = plugin.getMatchManager();
+        
+        if (matchManager == null) {
+            player.sendMessage("§cMatchManager not initialized.");
+            return true;
+        }
+        
+        if (args.length == 0) {
+            sendUsage(player);
+            return true;
+        }
+        
+        // Find target player
+        Player targetPlayer = Bukkit.getPlayer(args[0]);
+        if (targetPlayer == null || !targetPlayer.isOnline()) {
+            player.sendMessage("§cPlayer not found: §e" + args[0]);
+            return true;
+        }
+        
+        // Check if player is in a match
+        String matchId = matchManager.getMatchIdForPlayer(targetPlayer.getUniqueId());
+        if (matchId == null) {
+            player.sendMessage("§c" + targetPlayer.getName() + " is not registered in an active match.");
+            return true;
+        }
+        
+        BaseGame game = matchManager.getGameForMatch(matchId);
+        if (game == null) {
+            player.sendMessage("§cNo game instance found (legacy match?).");
+            return true;
+        }
+        
+        // Check if player is actually in disconnected state
+        if (!game.isPlayerDisconnected(targetPlayer.getUniqueId())) {
+            player.sendMessage("§e" + targetPlayer.getName() + " §7is not in disconnected state.");
+            player.sendMessage("§7Use §e/simulatedisconnect §7first to simulate disconnect.");
+            return true;
+        }
+        
+        player.sendMessage("§eSimulating reconnect for §f" + targetPlayer.getName());
+        
+        // Delegate to match manager
+        boolean success = matchManager.delegatePlayerReconnect(targetPlayer.getUniqueId());
+        
+        if (success) {
+            player.sendMessage("§aReconnect successful! §7Player resumed in game.");
+            LOGGER.info("Simulated reconnect for " + targetPlayer.getName() + " - success");
+        } else {
+            player.sendMessage("§cReconnect failed. §7Grace period may have expired.");
+            LOGGER.info("Simulated reconnect for " + targetPlayer.getName() + " - failed");
+        }
+        
+        return true;
+    }
+    
+    private void sendUsage(Player player) {
+        player.sendMessage("§6=== Simulate Reconnect Command ===");
+        player.sendMessage("§e/simulatereconnect <player> §7- Simulate reconnect");
+        player.sendMessage("§7Use after §e/simulatedisconnect §7to test grace period.");
+    }
+    
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        List<String> completions = new ArrayList<>();
+        
+        if (args.length == 1) {
+            // Player names
+            String partial = args[0].toLowerCase();
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getName().toLowerCase().startsWith(partial)) {
+                    completions.add(p.getName());
+                }
+            }
+        }
+        
+        return completions;
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/SimulateReconnectCommand.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/SimulateReconnectCommand.java
@@ -58,23 +58,27 @@ public class SimulateReconnectCommand implements CommandExecutor, TabCompleter {
             return true;
         }
         
-        // Check if player is in a match
-        String matchId = matchManager.getMatchIdForPlayer(targetPlayer.getUniqueId());
-        if (matchId == null) {
-            player.sendMessage("§c" + targetPlayer.getName() + " is not registered in an active match.");
+        // Check if player is in a grace period (disconnected but can reconnect)
+        if (!matchManager.isPlayerInGracePeriod(targetPlayer.getUniqueId())) {
+            // Also check if they're in a match but not in grace period
+            String matchId = matchManager.getMatchIdForPlayer(targetPlayer.getUniqueId());
+            if (matchId != null) {
+                BaseGame game = matchManager.getGameForMatch(matchId);
+                if (game != null && game.isPlayerDisconnected(targetPlayer.getUniqueId())) {
+                    player.sendMessage("§e" + targetPlayer.getName() + " §7is marked as disconnected but not in grace period.");
+                    player.sendMessage("§7Their grace period may have expired or they used instant forfeit.");
+                    return true;
+                }
+            }
+            player.sendMessage("§e" + targetPlayer.getName() + " §7is not in a grace period.");
+            player.sendMessage("§7Use §e/simulatedisconnect §7first to simulate disconnect.");
             return true;
         }
         
+        String matchId = matchManager.getGracePeriodMatchId(targetPlayer.getUniqueId());
         BaseGame game = matchManager.getGameForMatch(matchId);
         if (game == null) {
-            player.sendMessage("§cNo game instance found (legacy match?).");
-            return true;
-        }
-        
-        // Check if player is actually in disconnected state
-        if (!game.isPlayerDisconnected(targetPlayer.getUniqueId())) {
-            player.sendMessage("§e" + targetPlayer.getName() + " §7is not in disconnected state.");
-            player.sendMessage("§7Use §e/simulatedisconnect §7first to simulate disconnect.");
+            player.sendMessage("§cNo game instance found for match " + matchId);
             return true;
         }
         

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/TestGameCommand.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/TestGameCommand.java
@@ -1,0 +1,315 @@
+package ai.blockwarriors.commands.debug;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.WorldType;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import ai.blockwarriors.beacon.Plugin;
+import ai.blockwarriors.beacon.arena.ArenaConfig;
+import ai.blockwarriors.beacon.arena.ArenaManager;
+import ai.blockwarriors.beacon.constants.GameConfig;
+import ai.blockwarriors.beacon.game.BaseGame;
+import ai.blockwarriors.beacon.game.GameRegistry;
+import ai.blockwarriors.beacon.service.MatchManager;
+
+/**
+ * Debug command to start a local test match without Convex.
+ * 
+ * Usage:
+ *   /testgame <game_type>                    - Start with sender and a random online player
+ *   /testgame <game_type> <player1> <player2> - Start with specified players
+ *   /testgame list                           - List registered game types
+ */
+public class TestGameCommand implements CommandExecutor, TabCompleter {
+    
+    private static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    private final Plugin plugin;
+    
+    public TestGameCommand(Plugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cThis command can only be used by players.");
+            return true;
+        }
+        
+        Player player = (Player) sender;
+        
+        if (args.length == 0) {
+            sendUsage(player);
+            return true;
+        }
+        
+        String subCommand = args[0].toLowerCase();
+        
+        // Handle "list" subcommand
+        if (subCommand.equals("list")) {
+            listGameTypes(player);
+            return true;
+        }
+        
+        // Otherwise, treat as game type
+        String gameType = subCommand;
+        
+        // Validate game type
+        if (!GameConfig.isValidGameType(gameType)) {
+            player.sendMessage("§cUnknown game type: §e" + gameType);
+            player.sendMessage("§7Use §e/testgame list §7to see available types.");
+            return true;
+        }
+        
+        // Get players
+        Player bluePlayer;
+        Player redPlayer;
+        
+        if (args.length >= 3) {
+            // Specified players
+            bluePlayer = Bukkit.getPlayer(args[1]);
+            redPlayer = Bukkit.getPlayer(args[2]);
+            
+            if (bluePlayer == null || !bluePlayer.isOnline()) {
+                player.sendMessage("§cPlayer not found or offline: §e" + args[1]);
+                return true;
+            }
+            if (redPlayer == null || !redPlayer.isOnline()) {
+                player.sendMessage("§cPlayer not found or offline: §e" + args[2]);
+                return true;
+            }
+        } else {
+            // Use sender as blue player
+            bluePlayer = player;
+            
+            // Find another online player for red team
+            redPlayer = findOpponent(player);
+            if (redPlayer == null) {
+                player.sendMessage("§cNo other players online to play against.");
+                player.sendMessage("§7Usage: §e/testgame " + gameType + " <player1> <player2>");
+                return true;
+            }
+        }
+        
+        if (bluePlayer.equals(redPlayer)) {
+            player.sendMessage("§cYou cannot play against yourself.");
+            return true;
+        }
+        
+        // Start the test match
+        player.sendMessage("§aStarting test match: §e" + gameType);
+        player.sendMessage("§7Blue: §b" + bluePlayer.getName() + " §7vs Red: §c" + redPlayer.getName());
+        
+        startTestMatch(gameType, bluePlayer, redPlayer);
+        return true;
+    }
+    
+    private void sendUsage(Player player) {
+        player.sendMessage("§6=== Test Game Command ===");
+        player.sendMessage("§e/testgame <game_type> §7- Start test match");
+        player.sendMessage("§e/testgame <game_type> <blue> <red> §7- With specific players");
+        player.sendMessage("§e/testgame list §7- List registered game types");
+    }
+    
+    private void listGameTypes(Player player) {
+        player.sendMessage("§6=== Available Game Types ===");
+        
+        // List all registered game types
+        GameRegistry registry = GameRegistry.getInstance();
+        Set<String> registered = registry.getRegisteredTypes();
+        
+        player.sendMessage("§7Registered in GameRegistry:");
+        if (registered.isEmpty()) {
+            player.sendMessage("§8  (none)");
+        } else {
+            for (String type : registered) {
+                GameRegistry.GameMetadata meta = registry.getMetadata(type);
+                if (meta != null) {
+                    player.sendMessage("§a  - " + type + " §7(" + meta.getDisplayName() + ")");
+                } else {
+                    player.sendMessage("§a  - " + type);
+                }
+            }
+        }
+        
+        player.sendMessage("§7All configured game types:");
+        for (String type : GameConfig.GAME_TYPES) {
+            boolean isRegistered = registered.contains(type);
+            String status = isRegistered ? "§a✓" : "§c✗";
+            player.sendMessage("§7  " + status + " §f" + type);
+        }
+    }
+    
+    private Player findOpponent(Player sender) {
+        for (Player p : Bukkit.getOnlinePlayers()) {
+            if (!p.equals(sender)) {
+                return p;
+            }
+        }
+        return null;
+    }
+    
+    private void startTestMatch(String gameType, Player bluePlayer, Player redPlayer) {
+        // Generate a test match ID
+        String matchId = "test_" + System.currentTimeMillis();
+        
+        // Create world
+        String worldName = createTestWorld(matchId);
+        if (worldName == null) {
+            bluePlayer.sendMessage("§cFailed to create test world.");
+            return;
+        }
+        
+        World world = Bukkit.getWorld(worldName);
+        if (world == null) {
+            bluePlayer.sendMessage("§cWorld not found after creation.");
+            return;
+        }
+        
+        List<Player> blueTeam = Collections.singletonList(bluePlayer);
+        List<Player> redTeam = Collections.singletonList(redPlayer);
+        
+        // Check if game type is registered
+        GameRegistry registry = GameRegistry.getInstance();
+        if (registry.isRegistered(gameType)) {
+            // Use GameRegistry
+            BaseGame game = registry.createGame(gameType, plugin, matchId);
+            if (game == null) {
+                bluePlayer.sendMessage("§cFailed to create game instance.");
+                return;
+            }
+            
+            // Get arena config
+            ArenaManager arenaManager = plugin.getArenaManager();
+            ArenaConfig arenaConfig = null;
+            if (arenaManager != null) {
+                arenaConfig = arenaManager.getDefaultArena(gameType);
+            }
+            
+            // Initialize and start game
+            game.initialize(world, arenaConfig, blueTeam, redTeam);
+            
+            // Register with match manager
+            MatchManager matchManager = plugin.getMatchManager();
+            if (matchManager != null) {
+                List<Player> allPlayers = new ArrayList<>();
+                allPlayers.addAll(blueTeam);
+                allPlayers.addAll(redTeam);
+                matchManager.registerMatch(matchId, worldName, allPlayers, game);
+            }
+            
+            game.start();
+            
+            LOGGER.info("Test game started: " + gameType + " (match: " + matchId + ")");
+        } else {
+            // Legacy fallback
+            LOGGER.info("Game type '" + gameType + "' not registered, using legacy test match");
+            startLegacyTestMatch(world, bluePlayer, redPlayer);
+        }
+    }
+    
+    private String createTestWorld(String matchId) {
+        // Find the lowest unused world number
+        int worldNumber = 1;
+        String worldName = "test_" + worldNumber;
+        while (Bukkit.getWorld(worldName) != null) {
+            worldNumber++;
+            worldName = "test_" + worldNumber;
+        }
+        
+        try {
+            WorldCreator creator = new WorldCreator(worldName);
+            creator.type(WorldType.FLAT);
+            creator.generateStructures(false);
+            
+            World world = creator.createWorld();
+            if (world == null) {
+                LOGGER.severe("Failed to create test world: " + worldName);
+                return null;
+            }
+            
+            // Configure world settings
+            world.setSpawnLocation(0, 64, 0);
+            world.setSpawnFlags(false, false);
+            world.setDifficulty(org.bukkit.Difficulty.PEACEFUL);
+            
+            LOGGER.info("Created test world: " + worldName + " for match " + matchId);
+            return worldName;
+            
+        } catch (Exception e) {
+            LOGGER.severe("Error creating test world: " + e.getMessage());
+            e.printStackTrace();
+            return null;
+        }
+    }
+    
+    private void startLegacyTestMatch(World world, Player bluePlayer, Player redPlayer) {
+        // Set both players to survival mode
+        bluePlayer.setGameMode(GameMode.SURVIVAL);
+        redPlayer.setGameMode(GameMode.SURVIVAL);
+        
+        // Teleport players to spawn positions
+        Location blueLoc = new Location(world, 10, 65, 0);
+        blueLoc.setYaw(-90);
+        Location redLoc = new Location(world, -10, 65, 0);
+        redLoc.setYaw(90);
+        
+        bluePlayer.teleport(blueLoc);
+        redPlayer.teleport(redLoc);
+        
+        // Clear inventories and reset health/hunger
+        bluePlayer.getInventory().clear();
+        redPlayer.getInventory().clear();
+        bluePlayer.setHealth(20.0);
+        redPlayer.setHealth(20.0);
+        bluePlayer.setFoodLevel(20);
+        redPlayer.setFoodLevel(20);
+        bluePlayer.setSaturation(20.0f);
+        redPlayer.setSaturation(20.0f);
+        
+        bluePlayer.sendMessage("§aLegacy test match started! Fight!");
+        redPlayer.sendMessage("§aLegacy test match started! Fight!");
+    }
+    
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        List<String> completions = new ArrayList<>();
+        
+        if (args.length == 1) {
+            // First arg: game type or "list"
+            String partial = args[0].toLowerCase();
+            
+            if ("list".startsWith(partial)) {
+                completions.add("list");
+            }
+            
+            for (String type : GameConfig.GAME_TYPES) {
+                if (type.startsWith(partial)) {
+                    completions.add(type);
+                }
+            }
+        } else if (args.length == 2 || args.length == 3) {
+            // Player names
+            String partial = args[args.length - 1].toLowerCase();
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getName().toLowerCase().startsWith(partial)) {
+                    completions.add(p.getName());
+                }
+            }
+        }
+        
+        return completions;
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/TriggerObjectiveCommand.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/TriggerObjectiveCommand.java
@@ -1,0 +1,182 @@
+package ai.blockwarriors.commands.debug;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Logger;
+
+import org.bukkit.Bukkit;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.TabCompleter;
+import org.bukkit.entity.Player;
+
+import ai.blockwarriors.beacon.Plugin;
+import ai.blockwarriors.beacon.game.BaseGame;
+import ai.blockwarriors.beacon.service.MatchManager;
+
+/**
+ * Debug command to simulate game objective events.
+ * 
+ * Usage:
+ *   /triggerobjective <objective_type>              - Trigger for self
+ *   /triggerobjective <objective_type> <player>    - Trigger for specific player
+ *   /triggerobjective list                          - List common objectives
+ */
+public class TriggerObjectiveCommand implements CommandExecutor, TabCompleter {
+    
+    private static final Logger LOGGER = Logger.getLogger("beacon");
+    
+    // Common objective types for tab completion
+    private static final String[] COMMON_OBJECTIVES = {
+        "flag_capture",
+        "flag_pickup",
+        "flag_return",
+        "bed_destroyed",
+        "wool_placed",
+        "wool_collected",
+        "checkpoint",
+        "goal_scored",
+        "tile_stepped",
+        "bridge_crossed"
+    };
+    
+    private final Plugin plugin;
+    
+    public TriggerObjectiveCommand(Plugin plugin) {
+        this.plugin = plugin;
+    }
+    
+    @Override
+    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
+        if (!(sender instanceof Player)) {
+            sender.sendMessage("§cThis command can only be used by players.");
+            return true;
+        }
+        
+        Player player = (Player) sender;
+        MatchManager matchManager = plugin.getMatchManager();
+        
+        if (matchManager == null) {
+            player.sendMessage("§cMatchManager not initialized.");
+            return true;
+        }
+        
+        if (args.length == 0) {
+            sendUsage(player);
+            return true;
+        }
+        
+        String subCommand = args[0].toLowerCase();
+        
+        if (subCommand.equals("list")) {
+            listObjectives(player);
+            return true;
+        }
+        
+        // Determine target player
+        Player targetPlayer;
+        if (args.length >= 2) {
+            targetPlayer = Bukkit.getPlayer(args[1]);
+            if (targetPlayer == null || !targetPlayer.isOnline()) {
+                player.sendMessage("§cPlayer not found: §e" + args[1]);
+                return true;
+            }
+        } else {
+            targetPlayer = player;
+        }
+        
+        // Check if player is in a match
+        String matchId = matchManager.getMatchIdForPlayer(targetPlayer.getUniqueId());
+        if (matchId == null) {
+            player.sendMessage("§c" + targetPlayer.getName() + " is not in an active match.");
+            return true;
+        }
+        
+        BaseGame game = matchManager.getGameForMatch(matchId);
+        if (game == null) {
+            player.sendMessage("§cNo game instance found (legacy match?).");
+            return true;
+        }
+        
+        if (!game.isActive()) {
+            player.sendMessage("§cGame is not currently active.");
+            return true;
+        }
+        
+        String objectiveType = args[0];
+        
+        // Build objective data (could be extended to parse additional args)
+        Map<String, Object> data = new HashMap<>();
+        data.put("triggered_by_command", true);
+        data.put("sender", player.getName());
+        
+        // Parse additional key=value pairs
+        for (int i = 2; i < args.length; i++) {
+            String[] parts = args[i].split("=", 2);
+            if (parts.length == 2) {
+                data.put(parts[0], parts[1]);
+            }
+        }
+        
+        // Trigger the objective via MatchManager delegation
+        boolean handled = matchManager.delegateObjective(targetPlayer, objectiveType, data);
+        
+        if (handled) {
+            player.sendMessage("§aTriggered objective: §e" + objectiveType + " §afor §e" + targetPlayer.getName());
+            LOGGER.info("Objective " + objectiveType + " triggered by command for " + targetPlayer.getName());
+        } else {
+            player.sendMessage("§eObjective not handled by game: §7" + objectiveType);
+            player.sendMessage("§7The game may not support this objective type.");
+        }
+        
+        return true;
+    }
+    
+    private void sendUsage(Player player) {
+        player.sendMessage("§6=== Trigger Objective Command ===");
+        player.sendMessage("§e/triggerobjective <type> §7- Trigger for self");
+        player.sendMessage("§e/triggerobjective <type> <player> §7- Trigger for player");
+        player.sendMessage("§e/triggerobjective <type> <player> key=value §7- With data");
+        player.sendMessage("§e/triggerobjective list §7- List common objectives");
+    }
+    
+    private void listObjectives(Player player) {
+        player.sendMessage("§6=== Common Objective Types ===");
+        player.sendMessage("§7These are common objectives. Game-specific types may vary.");
+        for (String obj : COMMON_OBJECTIVES) {
+            player.sendMessage("§a  - " + obj);
+        }
+    }
+    
+    @Override
+    public List<String> onTabComplete(CommandSender sender, Command command, String label, String[] args) {
+        List<String> completions = new ArrayList<>();
+        
+        if (args.length == 1) {
+            String partial = args[0].toLowerCase();
+            
+            if ("list".startsWith(partial)) {
+                completions.add("list");
+            }
+            
+            for (String obj : COMMON_OBJECTIVES) {
+                if (obj.startsWith(partial)) {
+                    completions.add(obj);
+                }
+            }
+        } else if (args.length == 2) {
+            // Player names
+            String partial = args[1].toLowerCase();
+            for (Player p : Bukkit.getOnlinePlayers()) {
+                if (p.getName().toLowerCase().startsWith(partial)) {
+                    completions.add(p.getName());
+                }
+            }
+        }
+        
+        return completions;
+    }
+}

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/events/MatchEventListener.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/events/MatchEventListener.java
@@ -6,6 +6,8 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerKickEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 
 import ai.blockwarriors.beacon.game.DisconnectReason;
@@ -79,7 +81,18 @@ public class MatchEventListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGH)
     public void onPlayerQuit(PlayerQuitEvent event) {
-        Player player = event.getPlayer();
+        handlePlayerDisconnect(event.getPlayer(), DisconnectReason.QUIT);
+    }
+    
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlayerKick(PlayerKickEvent event) {
+        handlePlayerDisconnect(event.getPlayer(), DisconnectReason.KICK);
+    }
+    
+    /**
+     * Common handler for player disconnects (quit or kick).
+     */
+    private void handlePlayerDisconnect(Player player, DisconnectReason reason) {
         UUID playerId = player.getUniqueId();
 
         // Check if player is in an active match
@@ -92,10 +105,10 @@ public class MatchEventListener implements Listener {
             return;
         }
 
-        LOGGER.info("Player " + player.getName() + " disconnected from match " + matchId);
+        LOGGER.info("Player " + player.getName() + " disconnected from match " + matchId + " (reason: " + reason + ")");
 
         // Try to delegate to game instance first
-        DisconnectResult result = matchManager.delegatePlayerDisconnect(playerId, DisconnectReason.QUIT);
+        DisconnectResult result = matchManager.delegatePlayerDisconnect(playerId, reason);
         if (result != null) {
             LOGGER.info("Disconnect handled by game instance: " + result);
             return; // Game handled it
@@ -119,6 +132,31 @@ public class MatchEventListener implements Listener {
 
         // End the match with the other player as winner
         matchManager.endMatch(matchId, winnerId != null ? winnerId.toString() : null);
+    }
+    
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlayerJoin(PlayerJoinEvent event) {
+        Player player = event.getPlayer();
+        UUID playerId = player.getUniqueId();
+        
+        // Check if player was in a grace period (disconnected but can reconnect)
+        if (!matchManager.isPlayerInGracePeriod(playerId)) {
+            return;
+        }
+        
+        String matchId = matchManager.getGracePeriodMatchId(playerId);
+        LOGGER.info("Player " + player.getName() + " rejoined during grace period for match " + matchId);
+        
+        // Try to handle reconnection
+        boolean handled = matchManager.delegatePlayerReconnect(playerId);
+        
+        if (handled) {
+            player.sendMessage("§aWelcome back! You have reconnected to your match.");
+            LOGGER.info("Player " + player.getName() + " successfully reconnected to match " + matchId);
+        } else {
+            player.sendMessage("§cFailed to reconnect to match. The match may have ended.");
+            LOGGER.warning("Player " + player.getName() + " failed to reconnect to match " + matchId);
+        }
     }
 }
 

--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/events/MatchEventListener.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/events/MatchEventListener.java
@@ -1,18 +1,23 @@
 package ai.blockwarriors.events;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
 
+import ai.blockwarriors.beacon.game.DisconnectReason;
+import ai.blockwarriors.beacon.game.DisconnectResult;
 import ai.blockwarriors.beacon.service.MatchManager;
 
 import java.util.logging.Logger;
 import java.util.UUID;
 
 /**
- * Handles match-related events like player deaths
+ * Handles match-related events like player deaths and disconnects.
+ * Delegates to BaseGame instances when available, falls back to legacy behavior otherwise.
  */
 public class MatchEventListener implements Listener {
     private final MatchManager matchManager;
@@ -39,11 +44,21 @@ public class MatchEventListener implements Listener {
 
         LOGGER.info("Player " + deadPlayer.getName() + " died in match " + matchId);
 
-        // Find the winner (the other player in the match)
+        // Get killer (may be null for environmental deaths)
+        Player killer = deadPlayer.getKiller();
+
+        // Try to delegate to game instance first
+        if (matchManager.delegatePlayerDeath(deadPlayer, killer)) {
+            LOGGER.info("Death handled by game instance for match " + matchId);
+            return; // Game handled it
+        }
+
+        // Legacy fallback: Find the winner (the other player in the match)
+        LOGGER.info("Using legacy death handling for match " + matchId);
         UUID winnerId = null;
         for (UUID playerId : matchManager.getPlayersInMatch(matchId)) {
             if (!playerId.equals(deadPlayerId)) {
-                Player winner = org.bukkit.Bukkit.getPlayer(playerId);
+                Player winner = Bukkit.getPlayer(playerId);
                 if (winner != null && winner.isOnline()) {
                     winnerId = playerId;
                     winner.sendMessage("§aYou won the match! " + deadPlayer.getName() + " has been eliminated.");
@@ -60,6 +75,50 @@ public class MatchEventListener implements Listener {
             // No winner found (both players might have died simultaneously or other player left)
             matchManager.endMatch(matchId, null);
         }
+    }
+
+    @EventHandler(priority = EventPriority.HIGH)
+    public void onPlayerQuit(PlayerQuitEvent event) {
+        Player player = event.getPlayer();
+        UUID playerId = player.getUniqueId();
+
+        // Check if player is in an active match
+        if (!matchManager.isPlayerInMatch(playerId)) {
+            return;
+        }
+
+        String matchId = matchManager.getMatchIdForPlayer(playerId);
+        if (matchId == null) {
+            return;
+        }
+
+        LOGGER.info("Player " + player.getName() + " disconnected from match " + matchId);
+
+        // Try to delegate to game instance first
+        DisconnectResult result = matchManager.delegatePlayerDisconnect(playerId, DisconnectReason.QUIT);
+        if (result != null) {
+            LOGGER.info("Disconnect handled by game instance: " + result);
+            return; // Game handled it
+        }
+
+        // Legacy fallback: Treat disconnect as forfeit
+        LOGGER.info("Using legacy disconnect handling for match " + matchId);
+
+        // Find the winner (the other player who is still connected)
+        UUID winnerId = null;
+        for (UUID otherPlayerId : matchManager.getPlayersInMatch(matchId)) {
+            if (!otherPlayerId.equals(playerId)) {
+                Player winner = Bukkit.getPlayer(otherPlayerId);
+                if (winner != null && winner.isOnline()) {
+                    winnerId = otherPlayerId;
+                    winner.sendMessage("§aYou won the match! " + player.getName() + " has disconnected.");
+                    break;
+                }
+            }
+        }
+
+        // End the match with the other player as winner
+        matchManager.endMatch(matchId, winnerId != null ? winnerId.toString() : null);
     }
 }
 

--- a/apps/blockwarriors-beacon/src/main/resources/arenas/pvp.yml
+++ b/apps/blockwarriors-beacon/src/main/resources/arenas/pvp.yml
@@ -1,0 +1,29 @@
+# Default PvP Arena Configuration
+# This arena is used for 1v1 PvP matches
+
+name: "PvP Arena"
+game_type: "pvp"
+
+# Optional: WorldEdit schematic file (relative to schematics folder)
+# schematic: "pvp_arena.schem"
+
+# Team spawn points (relative to arena origin)
+spawns:
+  blue_team:
+    - {x: 10, y: 65, z: 0, yaw: -90, pitch: 0}
+  red_team:
+    - {x: -10, y: 65, z: 0, yaw: 90, pitch: 0}
+
+# Arena boundaries for out-of-bounds detection
+boundaries:
+  min: {x: -30, y: 50, z: -30}
+  max: {x: 30, y: 100, z: 30}
+
+# Game-specific objectives (none for basic PvP)
+objectives: {}
+
+# Resource spawns (none for basic PvP)
+resources: []
+
+# Special block locations (none for basic PvP)
+special_blocks: {}

--- a/apps/blockwarriors-beacon/src/main/resources/plugin.yml
+++ b/apps/blockwarriors-beacon/src/main/resources/plugin.yml
@@ -17,3 +17,27 @@ commands:
     description: Bypass login requirement (operators only)
     usage: /bypass [player]
     permission: beacon.bypass
+  testgame:
+    description: Start a local test match without Convex
+    usage: /testgame <game_type> [player1] [player2]
+    permission: beacon.debug
+  setarena:
+    description: Load an arena for testing
+    usage: /setarena <arena_name|list|reload>
+    permission: beacon.debug
+  endgame:
+    description: Force end the current game
+    usage: /endgame [winner|blue|red|none]
+    permission: beacon.debug
+  triggerobjective:
+    description: Simulate a game objective event
+    usage: /triggerobjective <objective_type> [player] [key=value...]
+    permission: beacon.debug
+  simulatedisconnect:
+    description: Simulate player disconnect for testing
+    usage: /simulatedisconnect <player> [reason]
+    permission: beacon.debug
+  simulatereconnect:
+    description: Simulate player reconnect during grace period
+    usage: /simulatereconnect <player>
+    permission: beacon.debug

--- a/packages/shared/constants/game-config.json
+++ b/packages/shared/constants/game-config.json
@@ -7,6 +7,27 @@
       "tokensPerTeam": 1,
       "players": "1v1"
     },
+    "sky_tiles": {
+      "id": "sky_tiles",
+      "name": "Sky Tiles",
+      "description": "Cooperative tile-based traversal",
+      "tokensPerTeam": 1,
+      "players": "2-player co-op"
+    },
+    "wool_wars": {
+      "id": "wool_wars",
+      "name": "Wool Wars",
+      "description": "Team-based wool capturing",
+      "tokensPerTeam": 4,
+      "players": "4v4"
+    },
+    "bridge": {
+      "id": "bridge",
+      "name": "Bridge Challenge",
+      "description": "Pathfinding race with obstacles",
+      "tokensPerTeam": 1,
+      "players": "1v1"
+    },
     "bedwars": {
       "id": "bedwars",
       "name": "Bed Wars",


### PR DESCRIPTION
# Multi-Game Infrastructure Plan

This plan establishes the foundational infrastructure for supporting multiple game types (Sky Tiles, Wool Wars, Bridge Challenge) while maintaining a clean developer experience for game implementers.

## Architecture Overview

```mermaid
flowchart TB
    subgraph Frontend [Next.js Frontend]
        PracticePage[Practice Page]
        GameSelect[Game Type Selection]
    end
    
    subgraph Backend [Convex Backend]
        GameConfig[game-config.json]
        MatchesAPI[Matches API]
        Schema[Schema]
    end
    
    subgraph Beacon [Beacon Plugin - Java]
        GameRegistry[GameRegistry]
        BaseGame[BaseGame Abstract Class]
        GameImpl[Game Implementations]
        ArenaManager[ArenaManager]
        MatchPolling[MatchPollingService]
        Telemetry[MatchTelemetryService]
    end
    
    PracticePage --> GameSelect
    GameSelect --> MatchesAPI
    MatchesAPI --> GameConfig
    MatchPolling --> MatchesAPI
    MatchPolling --> GameRegistry
    GameRegistry --> BaseGame
    GameImpl --> BaseGame
    GameImpl --> ArenaManager
    Telemetry --> GameRegistry
```

## Phase 1: Game Registry and Abstract Interface

### 1.1 Create `BaseGame` Abstract Class

Create a new file `apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/BaseGame.java`:

- Abstract class defining the contract all games must implement
- Methods: `initialize()`, `start()`, `handlePlayerDeath()`, `handleObjective()`, `checkWinCondition()`, `getGameState()`, `cleanup()`
- Properties: `gameType`, `matchId`, `players`, `teams`, `arenaConfig`

### 1.2 Create `GameRegistry` Service

Create `apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/game/GameRegistry.java`:

- Singleton registry mapping game type strings to game factory instances
- Method to instantiate games by type
- Auto-discovery or manual registration of game implementations

### 1.3 Update `GameConfig.java`

Extend [apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/constants/GameConfig.java](apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/constants/GameConfig.java) with:

- Arena configuration paths
- Game-specific constants (spawn points, objectives)

## Phase 2: Arena Management System

### 2.1 Create `ArenaManager` Service

Create `apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/arena/ArenaManager.java`:

- Load/save arena schematics (using WorldEdit API or custom NBT)
- Methods: `loadArena(String arenaName, World world)`, `getSpawnPoints(String arenaName, String team)`
- Arena configuration files (YAML) specifying spawn points, boundaries, objectives

### 2.2 Arena Configuration Format

Create arena config structure at `apps/blockwarriors-beacon/src/main/resources/arenas/`:

```yaml
# arenas/sky_tiles.yml
name: "Sky Tiles"
game_type: "sky_tiles"
schematic: "sky_tiles_arena.schem"
spawns:
  blue_team: [{x: 10, y: 100, z: 0}]
  red_team: [{x: -10, y: 100, z: 0}]
boundaries:
  min: {x: -50, y: 80, z: -50}
  max: {x: 50, y: 150, z: 50}
objectives: []
```

## Phase 3: Game Lifecycle Integration

### 3.1 Update `MatchPollingService`

Modify [apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchPollingService.java](apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchPollingService.java):

- Replace hardcoded `createMatch()` with `GameRegistry.createGame(matchType)`
- Pass arena configuration to games
- Support variable team sizes based on game type

### 3.2 Update `MatchManager`

Modify [apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchManager.java](apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchManager.java):

- Store `BaseGame` instances instead of just world references
- Delegate event handling to the active game instance
- Track game-specific state

### 3.3 Create `GameEventDispatcher`

Create event dispatcher that routes Bukkit events to the appropriate game instance:

- Death events, block events, entity events, custom objective events

## Phase 4: Player Disconnect Handling

### 4.1 Disconnect Detection

Update `PlayerEventListener` to handle `PlayerQuitEvent` and `PlayerKickEvent`:

```java
@EventHandler
public void onPlayerQuit(PlayerQuitEvent event) {
    UUID playerId = event.getPlayer().getUniqueId();
    String matchId = matchManager.getMatchIdForPlayer(playerId);
    
    if (matchId != null) {
        BaseGame game = matchManager.getGameForMatch(matchId);
        game.handlePlayerDisconnect(playerId, DisconnectReason.QUIT);
    }
}
```

### 4.2 BaseGame Disconnect Contract

Add to `BaseGame` abstract class:

```java
public abstract class BaseGame {
    // ...existing methods...
    
    /**
     * Handle player disconnect. Game decides outcome:
     * - Forfeit: Other team wins immediately
     * - Grace period: Wait for reconnect (configurable)
     * - Continue: Game proceeds with remaining players (team games)
     */
    public abstract DisconnectResult handlePlayerDisconnect(UUID playerId, DisconnectReason reason);
    
    /**
     * Handle player reconnect during grace period
     */
    public abstract boolean handlePlayerReconnect(UUID playerId);
    
    /**
     * Get disconnect policy for this game type
     */
    public abstract DisconnectPolicy getDisconnectPolicy();
}

public enum DisconnectReason { QUIT, KICK, TIMEOUT }

public enum DisconnectResult { FORFEIT, GRACE_PERIOD, CONTINUE, GAME_CANCELLED }

public class DisconnectPolicy {
    int gracePeriodSeconds;      // 0 = instant forfeit
    int minPlayersPerTeam;       // Minimum players before forfeit
    boolean allowReconnect;      // Can players rejoin?
}
```

### 4.3 Disconnect Information Flow

```mermaid
sequenceDiagram
    participant Player
    participant Beacon
    participant Game as BaseGame
    participant Telemetry
    participant Convex
    
    Player->>Beacon: Disconnect Event
    Beacon->>Game: handlePlayerDisconnect()
    Game->>Game: Check policy / remaining players
    
    alt Instant Forfeit
        Game->>Beacon: DisconnectResult.FORFEIT
        Beacon->>Telemetry: queueFinalMatchState(winner)
        Telemetry->>Convex: POST /matches/update (Finished + winner)
    else Grace Period
        Game->>Beacon: DisconnectResult.GRACE_PERIOD
        Beacon->>Telemetry: Update state (player_disconnected)
        Telemetry->>Convex: POST /matches/update (state only)
        Note over Beacon: Start reconnect timer
    else Continue (Team Games)
        Game->>Beacon: DisconnectResult.CONTINUE
        Beacon->>Telemetry: Update state (player_left)
        Telemetry->>Convex: POST /matches/update (state only)
    end
```

### 4.4 Telemetry Updates for Disconnects

Add disconnect event to match state telemetry:

```json
{
  "matchId": "abc123",
  "timestamp": 1705500000000,
  "players": [...],
  "events": [
    {
      "type": "player_disconnect",
      "playerId": "uuid",
      "reason": "QUIT",
      "timestamp": 1705499990000,
      "result": "GRACE_PERIOD",
      "gracePeriodEnds": 1705500030000
    }
  ],
  "disconnectedPlayers": ["uuid1"],
  "gameSpecific": {...}
}
```

### 4.5 Backend Token Cleanup

The existing `/tokens/clear` endpoint in [packages/backend/convex/http.ts](packages/backend/convex/http.ts) handles token cleanup when players disconnect before match starts. For mid-match disconnects, tokens remain active until match ends (Finished/Terminated).

### 4.6 Game-Specific Disconnect Policies

| Game Type | Policy | Grace Period | Min Players |

|-----------|--------|--------------|-------------|

| PvP (1v1) | Instant forfeit | 0s | 1 per team |

| Sky Tiles | Grace period | 30s | 1 per team |

| Wool Wars | Continue/forfeit | 60s | 2 per team |

| Bridge | Instant forfeit | 0s | 1 per team |

## Phase 5: Telemetry Extensions

### 5.1 Update `MatchTelemetryService`

Modify [apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchTelemetryService.java](apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/service/MatchTelemetryService.java):

- Add `getGameState()` call to `BaseGame` for game-specific telemetry
- Merge base player telemetry with game-specific data
- Support custom telemetry fields per game type

### 5.2 Backend Schema Support

The existing `match_state: v.any()` field in [packages/backend/convex/schema.ts](packages/backend/convex/schema.ts) already supports arbitrary game state. Document expected shapes per game type.

## Phase 6: Configuration Updates

### 6.1 Add New Game Types

Update [packages/shared/constants/game-config.json](packages/shared/constants/game-config.json):

```json
{
  "sky_tiles": {
    "id": "sky_tiles",
    "name": "Sky Tiles",
    "description": "Cooperative tile-based traversal",
    "tokensPerTeam": 1,
    "players": "2-player co-op"
  },
  "wool_wars": {
    "id": "wool_wars",
    "name": "Wool Wars",
    "description": "Team-based wool capturing",
    "tokensPerTeam": 4,
    "players": "4v4"
  },
  "bridge": {
    "id": "bridge",
    "name": "Bridge Challenge",
    "description": "Pathfinding race with obstacles",
    "tokensPerTeam": 1,
    "players": "1v1"
  }
}
```

### 6.2 Sync Java Constants

Update [apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/constants/GameConfig.java](apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/beacon/constants/GameConfig.java) to mirror new game types.

## Phase 7: Arena Building and Schematic Creation

This section provides guidance for game developers on creating arenas for their games.

### 7.1 Arena Building Tools

**Recommended Tools:**

- **WorldEdit** (in-game): Use `//copy`, `//paste`, `//schematic save` commands
- **Axiom** (mod): Modern building tool with advanced features
- **MCEdit** (external): For large-scale terrain editing

**WorldEdit Schematic Workflow:**

```bash
# In-game commands (with WorldEdit installed)
//wand                           # Get selection wand
//pos1                           # Set first corner (or left-click with wand)
//pos2                           # Set second corner (or right-click with wand)
//copy                           # Copy selection to clipboard
//schematic save <name>          # Save as .schem file
```

### 7.2 Arena Design Guidelines

**Structural Requirements:**

- Include clear spawn points marked with specific blocks (e.g., gold blocks for blue team, iron blocks for red team)
- Define arena boundaries with barrier blocks or bedrock
- Use air blocks for void areas (players fall and respawn/die)
- Consider spectator viewing areas

**Performance Considerations:**

- Keep arenas under 100x100x100 blocks when possible
- Avoid excessive entities (item frames, armor stands)
- Use solid blocks over complex redstone

**Game-Specific Elements:**

| Game | Required Elements |

|------|-------------------|

| Sky Tiles | Tile grid, checkpoint markers, void below |

| Wool Wars | Team bases, wool placement zones, resource spawns |

| Bridge | Main path, coin bridges, trapdoor sections, checkpoints |

### 7.3 Arena File Structure

```
apps/blockwarriors-beacon/
├── src/main/resources/
│   ├── arenas/
│   │   ├── pvp.yml              # Arena config
│   │   ├── sky_tiles.yml
│   │   ├── wool_wars.yml
│   │   └── bridge.yml
│   └── schematics/
│       ├── pvp_arena.schem      # WorldEdit schematic
│       ├── sky_tiles_arena.schem
│       ├── wool_wars_arena.schem
│       └── bridge_arena.schem
```

### 7.4 Arena Configuration Schema

```yaml
# Example: arenas/wool_wars.yml
name: "Wool Wars Arena"
game_type: "wool_wars"
schematic: "wool_wars_arena.schem"

# Spawn points (relative to schematic origin)
spawns:
  blue_team:
    - {x: 50, y: 65, z: 10, yaw: 90, pitch: 0}
    - {x: 50, y: 65, z: -10, yaw: 90, pitch: 0}
    - {x: 50, y: 65, z: 20, yaw: 90, pitch: 0}
    - {x: 50, y: 65, z: -20, yaw: 90, pitch: 0}
  red_team:
    - {x: -50, y: 65, z: 10, yaw: -90, pitch: 0}
    - {x: -50, y: 65, z: -10, yaw: -90, pitch: 0}
    - {x: -50, y: 65, z: 20, yaw: -90, pitch: 0}
    - {x: -50, y: 65, z: -20, yaw: -90, pitch: 0}

# Arena boundaries (for out-of-bounds detection)
boundaries:
  min: {x: -60, y: 50, z: -40}
  max: {x: 60, y: 100, z: 40}
  
# Game-specific objectives/markers
objectives:
  blue_wool_zone: {x: 45, y: 65, z: 0}
  red_wool_zone: {x: -45, y: 65, z: 0}
  wool_spawns:
    - {x: 0, y: 70, z: 15}
    - {x: 0, y: 70, z: -15}

# Resource spawns (for games with item spawning)
resources:
  - type: "IRON_INGOT"
    location: {x: 0, y: 65, z: 0}
    interval_seconds: 10
    
# Special blocks (automatically detected or manually specified)
special_blocks:
  respawn_anchors: []      # Coordinates of respawn points
  objective_blocks: []      # Blocks players interact with
```

### 7.5 Testing Arenas Locally

```bash
# 1. Place schematic file in server's schematics folder
cp my_arena.schem server/plugins/WorldEdit/schematics/

# 2. In-game: Load and test
//schematic load my_arena
//paste

# 3. Use debug commands (once implemented)
/setarena my_arena        # Load arena via ArenaManager
/testgame wool_wars       # Start test match
```

### 7.6 Arena Validation Checklist

Before submitting an arena, verify:

- [ ] All spawn points are accessible and not inside blocks
- [ ] Spawn points face the correct direction (yaw/pitch)
- [ ] Boundaries contain all playable area
- [ ] No unintended escape routes
- [ ] Schematic loads without errors
- [ ] YAML config parses correctly
- [ ] Game objectives are reachable
- [ ] Performance is acceptable (no lag on paste)

## Phase 8: Developer Experience / Testing

### 8.1 Debug Commands

Create new commands in `apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/commands/debug/`:

- `/testgame <game_type>` - Start a local test match without Convex
- `/setarena <arena_name>` - Load an arena for testing
- `/triggerobjective <objective>` - Simulate game events
- `/endgame [winner]` - Force end a game

### 8.2 Local Testing Mode

Add configuration option in [apps/blockwarriors-beacon/src/main/resources/config.yml](apps/blockwarriors-beacon/src/main/resources/config.yml):

```yaml
development:
  local-testing: true
  skip-convex: false
  auto-fill-bots: true
```

### 8.3 Simulating Player Disconnects

Debug command for testing disconnect handling:

```
/simulatedisconnect <player> [reason]  # Test disconnect flow without actual disconnect
/simulatereconnect <player>            # Test reconnect during grace period
```

## Implementation Priority

1. **BaseGame + GameRegistry** (Core - blocks everything else)
2. **Player disconnect handling** (Critical for match integrity)
3. **Update MatchPollingService integration** (Enable game routing)
4. **ArenaManager basic implementation** (Games need arenas)
5. **Debug commands** (Developer testing)
6. **Telemetry extensions** (Nice to have)

## Files to Create

| File | Purpose |

|------|---------|

| `beacon/game/BaseGame.java` | Abstract game interface with disconnect handling |

| `beacon/game/GameRegistry.java` | Game type registry |

| `beacon/game/GameEventDispatcher.java` | Route events to games |

| `beacon/game/DisconnectPolicy.java` | Disconnect handling configuration |

| `beacon/game/impl/PvPGame.java` | Reference implementation |

| `beacon/arena/ArenaManager.java` | Arena loading/management |

| `beacon/arena/ArenaConfig.java` | Arena configuration POJO |

| `commands/debug/TestGameCommand.java` | Local testing command |

| `commands/debug/SimulateDisconnectCommand.java` | Test disconnect flow |

| `resources/arenas/pvp.yml` | Default arena config |

| `resources/schematics/` | Directory for arena schematics |

## Notes for Game Developers

Each game developer (Kevin, Victoria, Mark) will:

1. Create a class extending `BaseGame` (e.g., `SkyTilesGame.java`)
2. Implement `handlePlayerDisconnect()` with game-appropriate logic
3. Register their game in `GameRegistry`
4. Create an arena schematic using WorldEdit and a YAML config
5. Implement game-specific win conditions and events
6. Test locally using `/testgame sky_tiles`
7. Test disconnect scenarios using `/simulatedisconnect`