### PR TITLE
feat: highlight active page in dashboard sidebar

### DIFF
--- a/apps/blockwarriors-next/src/app/dashboard/(components)/DashboardSidebar.tsx
+++ b/apps/blockwarriors-next/src/app/dashboard/(components)/DashboardSidebar.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import Image from 'next/image';
 import {
   Tooltip,
@@ -56,20 +57,30 @@ interface NavButtonProps {
   href: string;
   children: React.ReactNode;
   hasCompletedSetup: boolean;
+  isActive: boolean;
 }
 
-const NavButton = ({ href, children, hasCompletedSetup }: NavButtonProps) => {
+const NavButton = ({ href, children, hasCompletedSetup, isActive }: NavButtonProps) => {
   if (!hasCompletedSetup && href !== '/dashboard/setup') {
     return <DisabledButton>{children}</DisabledButton>;
   }
   return (
-    <Button variant="ghost" className="w-full justify-start" asChild>
+    <Button
+      variant="ghost"
+      className={cn(
+        'w-full justify-start relative transition-colors',
+        isActive &&
+          'bg-primary/15 text-primary hover:bg-primary/20 hover:text-primary before:absolute before:left-0 before:top-1/2 before:-translate-y-1/2 before:h-3/5 before:w-[3px] before:rounded-full before:bg-primary'
+      )}
+      asChild
+    >
       <Link href={href}>{children}</Link>
     </Button>
   );
 };
 
 export function DashboardSidebar({ className = '' }: SidebarProps) {
+  const pathname = usePathname();
   const { data: session } = authClient.useSession();
   const userId = session?.user?.id;
 
@@ -79,6 +90,9 @@ export function DashboardSidebar({ className = '' }: SidebarProps) {
   );
 
   const hasCompletedSetup = Boolean(userProfile?.first_name && userProfile?.team);
+
+  const isActive = (href: string) =>
+    href === '/dashboard' ? pathname === '/dashboard' : pathname.startsWith(href);
 
   return (
     <div className={cn('pb-12 min-h-screen', className)}>
@@ -114,7 +128,7 @@ export function DashboardSidebar({ className = '' }: SidebarProps) {
         <div className="px-3">
           <div className="space-y-1">
             {!hasCompletedSetup && (
-              <NavButton href="/dashboard/setup" hasCompletedSetup={hasCompletedSetup}>
+              <NavButton href="/dashboard/setup" hasCompletedSetup={hasCompletedSetup} isActive={isActive('/dashboard/setup')}>
                 <div className="flex items-center gap-2">
                   <User className="h-4 w-4" />
                   Get Started (Required)
@@ -122,37 +136,37 @@ export function DashboardSidebar({ className = '' }: SidebarProps) {
               </NavButton>
             )}
 
-            <NavButton href="/dashboard" hasCompletedSetup={hasCompletedSetup}>
+            <NavButton href="/dashboard" hasCompletedSetup={hasCompletedSetup} isActive={isActive('/dashboard')}>
               <div className="flex items-center gap-2">
                 <Home className="h-4 w-4" />
                 Overview
               </div>
             </NavButton>
-            <NavButton href="/dashboard/matches" hasCompletedSetup={hasCompletedSetup}>
+            <NavButton href="/dashboard/matches" hasCompletedSetup={hasCompletedSetup} isActive={isActive('/dashboard/matches')}>
               <div className="flex items-center gap-2">
                 <Calendar className="h-4 w-4" />
                 Matches
               </div>
             </NavButton>
-            <NavButton href="/dashboard/teams" hasCompletedSetup={hasCompletedSetup}>
+            <NavButton href="/dashboard/teams" hasCompletedSetup={hasCompletedSetup} isActive={isActive('/dashboard/teams')}>
               <div className="flex items-center gap-2">
                 <Users className="h-4 w-4" />
                 All Teams
               </div>
             </NavButton>
-            <NavButton href="/dashboard/leaderboard" hasCompletedSetup={hasCompletedSetup}>
+            <NavButton href="/dashboard/leaderboard" hasCompletedSetup={hasCompletedSetup} isActive={isActive('/dashboard/leaderboard')}>
               <div className="flex items-center gap-2">
                 <Trophy className="h-4 w-4" />
                 Leaderboard
               </div>
             </NavButton>
-            <NavButton href="/dashboard/tournaments" hasCompletedSetup={hasCompletedSetup}>
+            <NavButton href="/dashboard/tournaments" hasCompletedSetup={hasCompletedSetup} isActive={isActive('/dashboard/tournaments')}>
               <div className="flex items-center gap-2">
                 <Swords className="h-4 w-4" />
                 Tournaments
               </div>
             </NavButton>
-            <NavButton href="/dashboard/practice" hasCompletedSetup={hasCompletedSetup}>
+            <NavButton href="/dashboard/practice" hasCompletedSetup={hasCompletedSetup} isActive={isActive('/dashboard/practice')}>
               <div className="flex items-center gap-2">
                 <Gamepad2 className="h-4 w-4" />
                 Practice
@@ -161,13 +175,13 @@ export function DashboardSidebar({ className = '' }: SidebarProps) {
 
             {hasCompletedSetup && (
               <div className="pt-4 mt-4 border-t border-border space-y-1">
-                <NavButton href="/dashboard/profile" hasCompletedSetup={hasCompletedSetup}>
+                <NavButton href="/dashboard/profile" hasCompletedSetup={hasCompletedSetup} isActive={isActive('/dashboard/profile')}>
                   <div className="flex items-center gap-2">
                     <User className="h-4 w-4" />
                     My Profile
                   </div>
                 </NavButton>
-                <NavButton href="/dashboard/team" hasCompletedSetup={hasCompletedSetup}>
+                <NavButton href="/dashboard/team" hasCompletedSetup={hasCompletedSetup} isActive={isActive('/dashboard/team')}>
                   <div className="flex items-center gap-2">
                     <Shield className="h-4 w-4" />
                     My Team


### PR DESCRIPTION
## Summary
- Adds active state detection to the dashboard sidebar using `usePathname()` from Next.js
- Active nav item gets a Princeton Orange left accent bar and tinted background so users can instantly see which page they're on
- Exact match for `/dashboard` (Overview), prefix match for all sub-routes (e.g. `/dashboard/matches/123` highlights Matches)

## Test plan
- [ ] Navigate to each dashboard page and verify the corresponding sidebar item is highlighted
- [ ] Verify sub-routes (e.g. `/dashboard/matches/[id]`) highlight their parent nav item
- [ ] Verify the Overview item is only highlighted on exactly `/dashboard`, not on sub-pages
- [ ] Verify disabled items (pre-setup) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)