### PR TITLE
fix: allow /bypass command for unauthenticated players

### DIFF
--- a/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/events/PlayerEventListener.java
+++ b/apps/blockwarriors-beacon/src/main/java/ai/blockwarriors/events/PlayerEventListener.java
@@ -60,11 +60,6 @@ public class PlayerEventListener implements Listener {
     @EventHandler
     public void onPlayerChat(AsyncPlayerChatEvent event) {
         if (!isPlayerAllowed(event.getPlayer().getUniqueId())) {
-            if (event.getMessage().startsWith("/login") || event.getMessage().startsWith("/re")) {
-                LOGGER.info("Logging in...");
-                event.getPlayer().sendMessage("Logging in...");
-                return;
-            }
             event.getPlayer().sendMessage("Please do /login <token> to login first.");
             LOGGER.info("Cancel chat event");
             event.setCancelled(true);
@@ -74,9 +69,8 @@ public class PlayerEventListener implements Listener {
     @EventHandler
     public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
         if (!isPlayerAllowed(event.getPlayer().getUniqueId())) {
-            if (event.getMessage().startsWith("/login") || event.getMessage().startsWith("/re")) {
-                LOGGER.info("Logging in...");
-                event.getPlayer().sendMessage("Logging in...");
+            String msg = event.getMessage().toLowerCase();
+            if (msg.startsWith("/login") || msg.startsWith("/re") || msg.startsWith("/bypass")) {
                 return;
             }
             event.getPlayer().sendMessage("Please do /login <token> to login first.");


### PR DESCRIPTION
## Summary

- `/bypass` was being blocked by the `PlayerCommandPreprocessEvent` handler because it only allowed `/login` and `/re` through for unauthenticated players
- Adds `/bypass` to the command allowlist so operators can use it before logging in
- Removes dead `/login` check from the `AsyncPlayerChatEvent` handler (chat messages never start with `/`)
- Makes command matching case-insensitive

## Test plan

- [x] Deployed to Fast Dev server and verified `/bypass` works for unauthenticated players

🤖 Generated with [Claude Code](https://claude.com/claude-code)