### PR TITLE
fix: resolve spawn EINVAL on Windows for beacon deploy

### DIFF
--- a/scripts/deploy-beacon.mjs
+++ b/scripts/deploy-beacon.mjs
@@ -48,7 +48,7 @@ async function main() {
 
   if (config.mode === 'upload' && !config.skipBuild) {
     logStep('Building Beacon JAR');
-    await runCommand(getNpmCommand(), ['run', 'build:beacon']);
+    await runCommand('npm', ['run', 'build:beacon']);
   }
 
   if (config.mode === 'upload') {
@@ -756,15 +756,12 @@ function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function getNpmCommand() {
-  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
-}
-
 function runCommand(command, args) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd: repoRoot,
       stdio: 'inherit',
+      shell: process.platform === 'win32',
     });
 
     child.on('error', reject);


### PR DESCRIPTION
## Summary

- Fixes `spawn EINVAL` error when running `npm run deploy:beacon` on Windows
- On Windows, `npm` is a `.cmd` batch file — `child_process.spawn` can't execute it without `shell: true`, causing an `EINVAL` error
- Enables `shell: true` only on Windows (`process.platform === 'win32'`) to avoid Node deprecation warnings on other platforms
- Removes unused `getNpmCommand()` helper that tried to work around this by using `npm.cmd` (insufficient — the shell is still needed)

## Test plan

- [x] `npm run deploy:beacon:dry-run` passes on macOS with no warnings
- [ ] Teammate confirms `npm run deploy:beacon` works on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)